### PR TITLE
cURL won't follow HTTP redirects by default, need the location option.

### DIFF
--- a/tutorials/getting-started/getting-started.md
+++ b/tutorials/getting-started/getting-started.md
@@ -85,7 +85,7 @@ npm
 If you get a "not found" error, run this:
 
 ```bash
-curl https://npmjs.org/install.sh | sh
+curl -L https://npmjs.org/install.sh | sh
 ```
 
 ##### Install git


### PR DESCRIPTION
A `GET` to https://npmjs.org/install.sh gives:

```
HTTP/1.1 301 Moved Permanently
Connection: keep-alive
Content-Length: 193
Content-Type: text/html
Date: Sat, 08 Nov 2014 23:28:17 GMT
Location: https://www.npmjs.org/install.sh
Server: nginx/1.4.6 (Ubuntu)
```

However cURL only interprets the Location header if the -L/--location option is passed, so the original command fails. It also seems like this is the command the npm maintainers prefer, see https://github.com/npm/npm#fancy-install-unix.
