### PR TITLE
Changed sidebar style from overflow: scroll to overflow: auto

### DIFF
--- a/stylesheets/_content.less
+++ b/stylesheets/_content.less
@@ -28,7 +28,7 @@
   top: 0;
   height: 100%;
   font-size: 16px;
-  overflow: scroll;
+  overflow: auto;
   width: 25%;
   margin-right: 5%;
   padding: 30px 15px;


### PR DESCRIPTION
Just ran across this minor issue where the sidebar in the documentation always shows scrollbars (even if the content doesn't actually overflow the height of the container). This is just a single line change - basically the same thing as https://github.com/apostrophecms/apostrophe/pull/1100

I have tested manually and confirmed that it works as expected!