### PR TITLE
Make layout of documentation landing page more compact

### DIFF
--- a/_layouts/landing-documentation.html
+++ b/_layouts/landing-documentation.html
@@ -19,53 +19,69 @@
   </div>
   <div class="inner">
     <div class="cards">
-      <div class="card tutorials">
-        <h4>Tutorials</h4>
-        <p>Our tutorials cover everything you need to know to get started as an Apostrophe developer. Everyone should start here. Our tutorials are progressive, so you can learn as you go.</p>
-        <p><a class="card-link" href="tutorials/index.html">Explore the Tutorials</a></p>
-      </div>
+      <a class="card minor" href="tutorials/index.html">
+        <img src="../images/illustration-tutorials.svg">
+        <div class="card-minor-text">
+          <h4>Tutorials</h4>
+          <p>Our tutorials cover everything you need to know to get started as an Apostrophe developer. Everyone should start here. Our tutorials are progressive, so you can learn as you go.</p>
+        </div>
+      </a>
 
-      <div class="card reference">
-        <h4>Technical Overviews</h4>
-        <p>Our technical overviews are ideal for pros who want to understand our decisions and philosophy.</p>
-        <p><a class="card-link" href="technical-overviews/index.html">Take the deep dive</a></p>
-      </div>
+      <a class="card minor" href="technical-overviews/index.html">
+        <img src="../images/illustration-reference.svg">
+        <div class="card-minor-text">
+          <h4>Technical Overviews</h4>
+          <p>Our technical overviews are ideal for pros who want to understand our decisions and philosophy.</p>
+        </div>
+      </a>
 
-      <div class="card reference">
-        <h4>Module Reference</h4>
-        <p>Our module reference provides complete coverage of Apostrophe's modules and their related object types. Each module provides a particular feature, often including both front and back end code.</p>
-        <p><a class="card-link" href="modules/index.html">Explore the Module Reference</a></p>
-      </div>
+      <a class="card minor" href="modules/index.html">
+        <img src="../images/illustration-reference.svg">
+        <div class="card-minor-text">
+          <h4>Module Reference</h4>
+          <p>Our module reference provides complete coverage of Apostrophe's modules and their related object types. Each module provides a particular feature, often including both front and back end code.</p>
+        </div>
+      </a>
 
-      <div class="card reference">
-        <h4>Nunjucks Filters</h4>
-        <p>Apostrophe is powered by the Nunjucks template language, which is compatible with Jinja and Twig. In addition to many helper functions, Apostrophe provides additional Nunjucks "filters" to transform data for output.</p>
-        <p><a class="card-link" href="nunjucks-filters.html">Explore the Nunjucks Filters</a></p>
-      </div>
+      <a class="card minor" href="nunjucks-filters.html">
+        <img src="../images/illustration-reference.svg">
+        <div class="card-minor-text">
+          <h4>Nunjucks Filters</h4>
+          <p>Apostrophe is powered by the Nunjucks template language, which is compatible with Jinja and Twig. In addition to many helper functions, Apostrophe provides additional Nunjucks "filters" to transform data for output.</p>
+        </div>
+      </a>
 
-      <div class="card tutorials">
-        <h4>Glossary</h4>
-        <p>Learn the language of Apostrophe.</p>
-        <p><a class="card-link" href="glossary.html">Check out the glossary</a></p>
-      </div>
+      <a class="card minor" href="glossary.html">
+        <img src="../images/illustration-tutorials.svg">
+        <div class="card-minor-text">
+          <h4>Glossary</h4>
+          <p>Learn the language of Apostrophe.</p>
+        </div>
+      </a>
 
-      <div class="card tutorials">
-        <h4>More Modules</h4>
-        <p>You've met the core modules that ship in the <code>apostrophe</code> npm module. But there are more. And you can create more.</p>
-        <p><a class="card-link" href="more-modules.html">Discover and create more Apostrophe modules</a></p>
-      </div>
+      <a class="card minor" href="more-modules.html">
+        <img src="../images/illustration-tutorials.svg">
+        <div class="card-minor-text">
+          <h4>More Modules</h4>
+          <p>You've met the core modules that ship in the <code>apostrophe</code> npm module. But there are more. And you can create more.</p>
+        </div>
+      </a>
 
-      <div class="card reference">
-        <h4>Core Server</h4>
-        <p>The core <code>apos</code> object on the server orchestrates the whole dance.</p>
-        <p><a class="card-link" href="core-server.html">Learn about the core</a></p>
-      </div>
+      <a class="card minor" href="core-server.html">
+        <img src="../images/illustration-reference.svg">
+        <div class="card-minor-text">
+          <h4>Core Server</h4>
+          <p>The core <code>apos</code> object on the server orchestrates the whole dance.</p>
+        </div>
+      </a>
 
-      <div class="card reference">
-        <h4>Core Browser</h4>
-        <p>The browser has an <code>apos</code> object too, tying it all together.</p>
-        <p><a class="card-link" href="core-browser.html">Learn about the core</a></p>
-      </div>
+      <a class="card minor" href="core-browser.html">
+        <img src="../images/illustration-reference.svg">
+        <div class="card-minor-text">
+          <h4>Core Browser</h4>
+          <p>The browser has an <code>apos</code> object too, tying it all together.</p>
+        </div>
+      </a>
 
     </div>
   </div>

--- a/stylesheets/_structure.less
+++ b/stylesheets/_structure.less
@@ -86,6 +86,12 @@
 
 .cards
 {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+
   width: 100%;
   margin: 0 -9px;
   font-size: 0px;
@@ -114,16 +120,46 @@
       &:hover { text-decoration: underline; }
     }
 
-    h4 { text-align: center; padding-top: 96px; background-repeat: no-repeat; background-position: 50% top; }
-    &.tutorials h4 { background-image: url('../images/illustration-tutorials.svg') }
-    &.reference h4 { background-image: url('../images/illustration-reference.svg') }
-    &.enterprise h4 { background-image: url('../images/illustration-enterprise.svg') }
-    &.roadmap h4 { background-image: url('../images/illustration-roadmap.svg') }
-    &.minor {
-      margin: 9px;
-      h4 {
-        padding-top: 0;
-      }
+    h4 {
+      text-align: center;
+      padding-top: 96px;
+      background-repeat: no-repeat;
+      background-position: 50% top;
+    }
+    &.enterprise h4 {
+      background-image: url('../images/illustration-enterprise.svg');
+    }
+    &.roadmap h4 {
+      background-image: url('../images/illustration-roadmap.svg');
+    }
+  }
+
+  .card.minor
+  {
+    margin: 9px;
+
+    h4
+    {
+      margin-bottom: .25em;
+      padding-top: 0;
+      text-align: left;
+    }
+    img
+    {
+      float: left;
+      width: 66px;
+    }
+  }
+  .card-minor-text
+  {
+    color: @dark;
+    float: left;
+    margin-left: 3em;
+    width: calc(~"100% - 66px - 3em");
+
+    p
+    {
+      margin-bottom: 0;
     }
   }
 }


### PR DESCRIPTION
The landing page of the documentation is very frequently visited if you're using the project to any greater extent. This page has two issues IMO. Firstly, it's the fact that the cards aren't truly links. That means if you Cmd/Ctrl+click them, they won't open in a new tab (oh, the frustration).

Secondly, it's the fact that the cards are so high, you neglect the sections further down on the page.

I attempted to address these nuisances by making the .card's into actual links, by removing the .card-link's nexted in them and by being just a tad more conservative about vertical spacing in the .card's.

This is not an attempt at starting some design by committee process by opening a PR first and not an issue, but rather I thought it might be more efficient to open a PR directly, since I would have implemented by proposed design in the browser anyway.

Here's what the landing page looks like with my changes:

![screenshot_2018-08-17 apostrophe documentation 1](https://user-images.githubusercontent.com/1101677/44273001-90741980-a23e-11e8-83c2-88fe55869da0.png)