### PR TITLE
Fixed a mistake in "how-apostrophe-handles-requests"

### DIFF
--- a/technical-overviews/how-apostrophe-handles-requests.md
+++ b/technical-overviews/how-apostrophe-handles-requests.md
@@ -57,7 +57,9 @@ For instance, you might implement a module that displays an index if you request
 ```javascript
 // in app.js
 modules: {
-  'home-pages': {}
+  'home-pages': {
+   extend: 'apostrophe-custom-pages'
+  }
 }
 
 // in lib/modules/home-pages/index.js


### PR DESCRIPTION
The "Dispatch: handling prefix URL matches with  apostrophe-custom-pages" example didn't extend the custom pages module.
