### PR TITLE
Remove `config.removeButtons` example code

### DIFF
--- a/tutorials/howtos/ckeditor.md
+++ b/tutorials/howtos/ckeditor.md
@@ -49,9 +49,6 @@ apos.define('apostrophe-rich-text-widgets-editor', {
     self.beforeCkeditorInline = function() {
       // Mess around with the `config` object about to be passed to CKEditor
       self.config.removePlugins = 'man-i-hate-this-particular-plugin';
-      // Disable Underline (as happens by default), but leave
-      // Superscript and Subscript enabled as potential toolbar items
-      self.config.removeButtons = 'Underline';
     };
   }
 });


### PR DESCRIPTION
The removeButtons config is now automatically altered depending on which buttons are specified in the template options' `toolbar` property, as per https://github.com/apostrophecms/apostrophe/pull/1779