### PR TITLE
Getting a BSON date with the integer type

### DIFF
--- a/tutorials/getting-started/schema-guide.md
+++ b/tutorials/getting-started/schema-guide.md
@@ -393,6 +393,8 @@ You may also want to set `contextual: true` so the field does not *also* appear 
 
 `integer` adds an editable integer field to the schema. You may set minimum and maximum values using the `min` and `max` options. Any fractional part is discarded.
 
+If you want a full date and time field you can use `integer` and set its value with `new Date()`, for instance. It will become a [MongoDB Date BSON type](https://docs.mongodb.com/manual/reference/bson-types/#date) on the database, wich is a 64 bit integer.
+
 Example:
 
 ```javascript
@@ -466,6 +468,8 @@ Example with configuration of date picker:
 **Note: Apostrophe tries its best to convert any date picker format to the above mentioned** `YYYY-MM-DD` **friendly sorting format, but very advanced configurations may not work out of the box, so please keep that in mind.**
 
 **If you do not set** `def: null` **or** `required: true`**, the date defaults to the current date.**
+
+If you want a native MongoDB `Date` BSON type, with date and time, you may use an [`integer`](#integer) field.
 
 ### `time`
 


### PR DESCRIPTION
I was using pure integers to represent the milliseconds since the Unix epoch... and when I tried new Date().. voilà! It worked. I didn't know it was possible to create a full date and time object with apostrophe schemas, maybe because I tried to set some _id to ObjectId() and everything stopped working.

Please, review my words if accepting these changes. I'm not a native english writer.