### PR TITLE
Remove `callback` from afterShow(callback)

### DIFF
--- a/modules/apostrophe-widgets/browser-apostrophe-widgets-editor.md
+++ b/modules/apostrophe-widgets/browser-apostrophe-widgets-editor.md
@@ -7,7 +7,7 @@
 
 ### beforeShow(*callback*)
 
-### afterShow(*callback*)
+### afterShow()
 Wait for afterShow to do things that might pop more modals
 ### getData()
 


### PR DESCRIPTION
I found out that the callback does not exist on this editor. It returns undefined from that argument. Is this adjustment, valid?