### PR TITLE
Joins example fix

### DIFF
--- a/tutorials/core-concepts/reusable-content-pieces/joins.md
+++ b/tutorials/core-concepts/reusable-content-pieces/joins.md
@@ -112,9 +112,9 @@ Here's what that looks like in `lib/modules/people/views/show.html`:
 {% code-tabs-item title="lib/modules/people/views/show.html" %}
 ```markup
 {# As in the earlier example, then... #}
-{% if data.person._job %}
+{% if data.piece._job %}
   <h4>
-    Position: <a href="{{ data.person._job._url }}">{{ data.person._job.title }}</a>
+    Position: <a href="{{ data.piece._job._url }}">{{ data.piece._job.title }}</a>
   </h4>
 {% endif %}
 ```


### PR DESCRIPTION
When going through the pieces tutorial, I couldn't get this one example to work. I looked through the open-museum demo and it seems like you do things like `{% set artist = data.piece._artist %}`. I'm assuming `{% set person = data.piece %}` and `{% if person._job %}` would follow your development style more closely, but simply changing `data.person` to `data.piece` works and keeps this whole document consistent.

Also, a massive thank you to the Apostrophe team for everything you do!