### PR TITLE
Hotfix/method regex

### DIFF
--- a/_api-reference-generator/lib/modules/documentation/index.js
+++ b/_api-reference-generator/lib/modules/documentation/index.js
@@ -92,7 +92,7 @@ module.exports = {
 
       fragment = `* [Module Reference](modules/README.md)\n` + fragment
       // console.log(fragment);
-      
+
       let summary = fs.readFileSync('../SUMMARY.md', 'utf8');
       summary = summary.replace(/\n## Modules[\s\S]*$/, '\n## Modules\n\n' + fragment + '\n[comment]: <> (DO NOT add anything AFTER the ## Modules heading or it will be lost.)');
       fs.writeFileSync('../SUMMARY.md', summary);
@@ -413,7 +413,7 @@ module.exports = {
         }
 
         // Make sure it's not commented out
-        var methodRegex = /\n +self\.(\w+)\s*=\s*function\((.*?)\)/g;
+        var methodRegex = /\n +self\.(\w+)\s*=\s*function\s*\((.*?)\)/g;
         while ((matches = methodRegex.exec(code)) !== null) {
           methods.push(processMethod(module, subcategory, file, matches, code, info));
         }

--- a/_api-reference-generator/package-lock.json
+++ b/_api-reference-generator/package-lock.json
@@ -15,9 +15,9 @@
       }
     },
     "@google-cloud/common": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-2.2.5.tgz",
-      "integrity": "sha512-Iw6LJj7V8XEVFDORCHC/I+YVmK98KmZSa8z10O4h2Wpkzlk/Sjj8Ruz4QJHawj7GwuWjQQ47O2Z4JECXf1S3ag==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-2.2.6.tgz",
+      "integrity": "sha512-gVjIZbdgOBTLC42AhhIUiYlETAz8tp/znRk6miJD8Dz2R+d8L60PIw7BIDIsZjcEQ2oSQJlcHYXhV9aK5Ug7DQ==",
       "requires": {
         "@google-cloud/projectify": "^1.0.0",
         "@google-cloud/promisify": "^1.0.0",
@@ -27,7 +27,7 @@
         "extend": "^3.0.2",
         "google-auth-library": "^5.5.0",
         "retry-request": "^4.0.0",
-        "teeny-request": "^5.2.1"
+        "teeny-request": "^6.0.0"
       }
     },
     "@google-cloud/paginator": {
@@ -50,9 +50,9 @@
       "integrity": "sha512-VccZDcOql77obTnFh0TbNED/6ZbbmHDf8UMNnzO1d5g9V0Htfm4k5cllY8P1tJsRKC3zWYGRLaViiupcgVjBoQ=="
     },
     "@google-cloud/storage": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-4.1.3.tgz",
-      "integrity": "sha512-79Ag+4eQq+KFJcKB85AimepoqTJOGuDLAmJd7JkLc8NM12a87JTCoGi65oi1eZ4H77AV0uUQxSS2Fo/hZL3+kQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-4.2.0.tgz",
+      "integrity": "sha512-KksntL3RCXShVaUkdxGzFUHvoGylMkOyl33bKe4skyu7NqpM4cQNuiDLg3mE5UOsK87J3p/j2z/TFH/BlzLzHA==",
       "requires": {
         "@google-cloud/common": "^2.1.1",
         "@google-cloud/paginator": "^2.0.0",
@@ -84,9 +84,9 @@
           "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
         },
         "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
+          "integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -138,12 +138,9 @@
       "integrity": "sha512-7Bv1We7ZGuU79zZbb6rRqcpxo3OY+zrdtloZWoyD8fmGX+FeXRjE+iuGkZjSXLVovLzrsvMGMy0EkwA0E0umxg=="
     },
     "agent-base": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-      "requires": {
-        "es6-promisify": "^5.0.0"
-      }
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
+      "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g=="
     },
     "ajv": {
       "version": "6.10.2",
@@ -209,9 +206,9 @@
       }
     },
     "apostrophe": {
-      "version": "2.100.2",
-      "resolved": "https://registry.npmjs.org/apostrophe/-/apostrophe-2.100.2.tgz",
-      "integrity": "sha512-yNTjSJeIw9ZtO7R1x0oTc6aU9bSn+Xbhu827koO8579xi5c2nRfCwLxpHSbXNi9Hpc6i95XDkjLdg2QRgdPgOQ==",
+      "version": "2.101.1",
+      "resolved": "https://registry.npmjs.org/apostrophe/-/apostrophe-2.101.1.tgz",
+      "integrity": "sha512-NW1eJYinnUzFZAKpnaSOY+RqdVS1str7lJBVqCSr4VPS1/4NiqUMeQQMRU2dlZTgrMPAquxLhRpjuWhhzIWgEQ==",
       "requires": {
         "@apostrophecms/nunjucks": "^2.5.3",
         "@sailshq/lodash": "^3.10.4",
@@ -222,13 +219,13 @@
         "cheerio": "^0.22.0",
         "cli-progress": "^2.1.1",
         "connect-flash": "^0.1.1",
-        "connect-mongo": "^1.3.2",
         "connect-multiparty": "^2.2.0",
         "cookie-parser": "^1.4.4",
         "credential": "^2.0.0",
         "cuid": "^1.3.8",
         "deep-get-set": "^0.1.1",
         "diff": "^4.0.1",
+        "emulate-mongo-2-driver": "^1.0.3",
         "express": "^4.17.1",
         "express-session": "^1.17.0",
         "glob": "^5.0.15",
@@ -244,7 +241,6 @@
         "minimatch": "^3.0.4",
         "mkdirp": "^0.5.1",
         "moment": "^2.23.0",
-        "mongodb": "^2.2.36",
         "moog-require": "^1.1.0",
         "nodemailer": "^4.7.0",
         "oembetter": "^0.1.19",
@@ -385,9 +381,9 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
     "aws-sdk": {
-      "version": "2.588.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.588.0.tgz",
-      "integrity": "sha512-2AJ0gA+hpTO2pTEWdh4JDFlsOCR3YxRGoUb+PYIgzSITs1phJS+mYyrrmBlBUPlwGIxtUn0IbZqqAOQxs7CIoA==",
+      "version": "2.608.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.608.0.tgz",
+      "integrity": "sha512-6utwjZGFW7gRpOhWc7F9KUnDWRWnaLtEaTjya6BwNsfYTk+z1GvL9UVu9WdZ0Y47IuJIiNuEWQ/xw0N0kEBcMw==",
       "requires": {
         "buffer": "4.9.1",
         "events": "1.1.1",
@@ -580,6 +576,24 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "bl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.0.tgz",
+      "integrity": "sha512-wbgvOpqopSr7uq6fJrLH8EsvYMJf9gzfo2jCsL2eTy75qXPukA4pCgHamOQkZtY5vmfVtjB+P3LNlMHW5CEZXA==",
+      "requires": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      }
+    },
     "bless": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/bless/-/bless-3.0.3.tgz",
@@ -676,9 +690,9 @@
       "integrity": "sha1-rrGvKN5sDXpqLOQK22j/GEIq8x8="
     },
     "bson": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.9.tgz",
-      "integrity": "sha512-IQX9/h7WdMBIW/q/++tGd+emQr0XMdeZ6icnT/74Xk9fnabWn+gZgpE+9V+gujL3hhJOoNrnDVY7tWdzc7NUTg=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.3.tgz",
+      "integrity": "sha512-TdiJxMVnodVS7r0BdL42y/pqC9cL2iKynVwA0Ho3qbsQYr428veL3l7BQyuqiw+Q5SqqoT0m4srSY/BlZ9AxXg=="
     },
     "buffer": {
       "version": "4.9.1",
@@ -704,11 +718,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
-    },
-    "buffer-shims": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
     },
     "bytes": {
       "version": "3.1.0",
@@ -937,11 +946,18 @@
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
     },
     "compressible": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.17.tgz",
-      "integrity": "sha512-BGHeLCK1GV7j1bSmQQAi26X+GgWcTjLr/0tzSvMCl3LH1w1IJ4PFSPoV5316b30cneTziC+B1a+3OjoSUcQYmw==",
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
       "requires": {
-        "mime-db": ">= 1.40.0 < 2"
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.43.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+          "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+        }
       }
     },
     "concat-map": {
@@ -961,9 +977,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
+          "integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -989,15 +1005,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/connect-flash/-/connect-flash-0.1.1.tgz",
       "integrity": "sha1-2GMPJtlaf4UfmVax6MxnMvO2qjA="
-    },
-    "connect-mongo": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/connect-mongo/-/connect-mongo-1.3.2.tgz",
-      "integrity": "sha1-fL9Y3/8mdg5eAOAX0KhbS8kLnTc=",
-      "requires": {
-        "bluebird": "^3.0",
-        "mongodb": ">= 1.2.0 <3.0.0"
-      }
     },
     "connect-multiparty": {
       "version": "2.2.0",
@@ -1147,9 +1154,9 @@
       }
     },
     "date-and-time": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-0.11.0.tgz",
-      "integrity": "sha512-VyzhHurex4wlg9oMszn7O+kxHchphWjzDn7Mv0WfkFKI6hSNOQePpTBFGsnRakvLNzQKXqPBAVV8DOxUGtUxqA=="
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-0.11.1.tgz",
+      "integrity": "sha512-+1JkWME+UWRpCfvE1T0Vfbw629Ego0IcfHH0qtP4KhAXs7IJT2qsg1hNePqZhyD8Wby46HlW393lSL5PZSzDsA=="
     },
     "debug": {
       "version": "2.6.9",
@@ -1170,16 +1177,29 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "deep-equal": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.1.tgz",
+      "integrity": "sha512-7Et6r6XfNW61CPPCIYfm1YPGSmh6+CliYeL4km7GWJcpX5LTAflGF8drLLR+MZX+2P3NZfAfSduutBbSWqER4g==",
       "requires": {
+        "es-abstract": "^1.16.3",
+        "es-get-iterator": "^1.0.1",
         "is-arguments": "^1.0.4",
         "is-date-object": "^1.0.1",
         "is-regex": "^1.0.4",
+        "isarray": "^2.0.5",
         "object-is": "^1.0.1",
         "object-keys": "^1.1.1",
-        "regexp.prototype.flags": "^1.2.0"
+        "regexp.prototype.flags": "^1.2.0",
+        "side-channel": "^1.0.1",
+        "which-boxed-primitive": "^1.0.1",
+        "which-collection": "^1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+        }
       }
     },
     "deep-get-set": {
@@ -1237,6 +1257,11 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
+    "denque": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
+      "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
+    },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -1248,9 +1273,9 @@
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "diff": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
-      "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
     },
     "dom-serializer": {
       "version": "0.1.1",
@@ -1329,6 +1354,14 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
+    "emulate-mongo-2-driver": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/emulate-mongo-2-driver/-/emulate-mongo-2-driver-1.0.4.tgz",
+      "integrity": "sha512-VD41KHJnWR/cOdiTx+vKJBI0iHPcuX+RuYDMwqoxncCBTp4ZJeJfM/rZ0XiyZKH9wGSwakRSeSGMUWXlbc2DnA==",
+      "requires": {
+        "mongodb": "^3.3.5"
+      }
+    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -1362,20 +1395,42 @@
       }
     },
     "es-abstract": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.3.tgz",
-      "integrity": "sha512-WtY7Fx5LiOnSYgF5eg/1T+GONaGmpvpPdCpSnYij+U2gDTL0UPfWrhDw7b2IYb+9NQJsYpCA0wOQvZfsd6YwRw==",
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
+      "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
-        "is-callable": "^1.1.4",
-        "is-regex": "^1.0.4",
+        "is-callable": "^1.1.5",
+        "is-regex": "^1.0.5",
         "object-inspect": "^1.7.0",
         "object-keys": "^1.1.1",
-        "string.prototype.trimleft": "^2.1.0",
-        "string.prototype.trimright": "^2.1.0"
+        "object.assign": "^4.1.0",
+        "string.prototype.trimleft": "^2.1.1",
+        "string.prototype.trimright": "^2.1.1"
+      }
+    },
+    "es-get-iterator": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.0.2.tgz",
+      "integrity": "sha512-ZHb4fuNK3HKHEOvDGyHPKf5cSWh/OvAMskeM/+21NMnTuvqFvz8uHatolu+7Kf6b6oK9C+3Uo1T37pSGPWv0MA==",
+      "requires": {
+        "es-abstract": "^1.17.0-next.1",
+        "has-symbols": "^1.0.1",
+        "is-arguments": "^1.0.4",
+        "is-map": "^2.0.0",
+        "is-set": "^2.0.0",
+        "is-string": "^1.0.4",
+        "isarray": "^2.0.5"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+        }
       }
     },
     "es-to-primitive": {
@@ -1389,24 +1444,9 @@
       }
     },
     "es6-promise": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
-      "integrity": "sha1-7FYjOGgDKQkgcXDDlEjiREndH8Q="
-    },
-    "es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "requires": {
-        "es6-promise": "^4.0.3"
-      },
-      "dependencies": {
-        "es6-promise": {
-          "version": "4.2.8",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-          "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
-        }
-      }
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "escape-html": {
       "version": "1.0.3",
@@ -1701,6 +1741,12 @@
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
       "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -1798,13 +1844,14 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
-      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
+      "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
       "optional": true,
       "requires": {
+        "bindings": "^1.5.0",
         "nan": "^2.12.1",
-        "node-pre-gyp": "^0.12.0"
+        "node-pre-gyp": "*"
       },
       "dependencies": {
         "abbrev": {
@@ -1846,7 +1893,7 @@
           }
         },
         "chownr": {
-          "version": "1.1.1",
+          "version": "1.1.3",
           "bundled": true,
           "optional": true
         },
@@ -1871,7 +1918,7 @@
           "optional": true
         },
         "debug": {
-          "version": "4.1.1",
+          "version": "3.2.6",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -1894,11 +1941,11 @@
           "optional": true
         },
         "fs-minipass": {
-          "version": "1.2.5",
+          "version": "1.2.7",
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.6.0"
           }
         },
         "fs.realpath": {
@@ -1922,7 +1969,7 @@
           }
         },
         "glob": {
-          "version": "7.1.3",
+          "version": "7.1.6",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -1948,7 +1995,7 @@
           }
         },
         "ignore-walk": {
-          "version": "3.0.1",
+          "version": "3.0.3",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -1965,7 +2012,7 @@
           }
         },
         "inherits": {
-          "version": "2.0.3",
+          "version": "2.0.4",
           "bundled": true,
           "optional": true
         },
@@ -2001,7 +2048,7 @@
           "optional": true
         },
         "minipass": {
-          "version": "2.3.5",
+          "version": "2.9.0",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -2010,11 +2057,11 @@
           }
         },
         "minizlib": {
-          "version": "1.2.1",
+          "version": "1.3.3",
           "bundled": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.9.0"
           }
         },
         "mkdirp": {
@@ -2026,22 +2073,22 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
+          "version": "2.1.2",
           "bundled": true,
           "optional": true
         },
         "needle": {
-          "version": "2.3.0",
+          "version": "2.4.0",
           "bundled": true,
           "optional": true,
           "requires": {
-            "debug": "^4.1.0",
+            "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
             "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
-          "version": "0.12.0",
+          "version": "0.14.0",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -2054,7 +2101,7 @@
             "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
-            "tar": "^4"
+            "tar": "^4.4.2"
           }
         },
         "nopt": {
@@ -2067,12 +2114,20 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.6",
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "npm-normalize-package-bin": "^1.0.1"
+          }
+        },
+        "npm-normalize-package-bin": {
+          "version": "1.0.1",
           "bundled": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.4.1",
+          "version": "1.4.7",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -2134,7 +2189,7 @@
           "optional": true
         },
         "process-nextick-args": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true,
           "optional": true
         },
@@ -2171,7 +2226,7 @@
           }
         },
         "rimraf": {
-          "version": "2.6.3",
+          "version": "2.7.1",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -2194,7 +2249,7 @@
           "optional": true
         },
         "semver": {
-          "version": "5.7.0",
+          "version": "5.7.1",
           "bundled": true,
           "optional": true
         },
@@ -2240,17 +2295,17 @@
           "optional": true
         },
         "tar": {
-          "version": "4.4.8",
+          "version": "4.4.13",
           "bundled": true,
           "optional": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
+            "minipass": "^2.8.6",
+            "minizlib": "^1.2.1",
             "mkdirp": "^0.5.0",
             "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "yallist": "^3.0.3"
           }
         },
         "util-deprecate": {
@@ -2272,7 +2327,7 @@
           "optional": true
         },
         "yallist": {
-          "version": "3.0.3",
+          "version": "3.1.1",
           "bundled": true,
           "optional": true
         }
@@ -2284,21 +2339,21 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "gaxios": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-2.2.0.tgz",
-      "integrity": "sha512-54Y7s3yvtEO9CZ0yBVQHI5fzS7TzkjlnuLdDEkeyL1SNYMv877VofvA56E/C3dvj3rS7GFiyMWl833Qrr+nrkg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-2.2.2.tgz",
+      "integrity": "sha512-fzttYsjvZxCaN+bQK7FtAMgoIlPtHkMwlz7vHD+aNRcU7I7gHgnp6hvGJksoo+dO1TDxaog+dSBycbYhHIStaA==",
       "requires": {
         "abort-controller": "^3.0.0",
         "extend": "^3.0.2",
-        "https-proxy-agent": "^3.0.0",
+        "https-proxy-agent": "^4.0.0",
         "is-stream": "^2.0.0",
         "node-fetch": "^2.3.0"
       }
     },
     "gcp-metadata": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-3.2.2.tgz",
-      "integrity": "sha512-vR7kcJMCYJG/mYWp/a1OszdOqnLB/XW1GorWW1hc1lWVNL26L497zypWb9cG0CYDQ4Bl1Wk0+fSZFFjwJlTQgQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-3.3.0.tgz",
+      "integrity": "sha512-uO3P/aByOQmoDu5bOYBODHmD1oDCZw7/R8SYY0MdmMQSZVEmeTSxmiM1vwde+YHYSpkaQnAAMAIZuOqLvgfp/Q==",
       "requires": {
         "gaxios": "^2.1.0",
         "json-bigint": "^0.3.0"
@@ -2398,24 +2453,24 @@
       }
     },
     "google-auth-library": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-5.7.0.tgz",
-      "integrity": "sha512-uclMldsQNf64Qr67O8TINdnqbU/Ixv81WryX+sF9g7uP0igJ98aCR/uU399u1ABLa53LNsyji+bo+bP8/iL9dA==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-5.9.1.tgz",
+      "integrity": "sha512-927NlfjqRLrkok2JRBap4iYqe5+bsdtaotwO1JSAAxoQmji+Xmf+pFLzB+52C8ovtfycwFXbvC9f/SB4gmQCXw==",
       "requires": {
         "arrify": "^2.0.0",
         "base64-js": "^1.3.0",
         "fast-text-encoding": "^1.0.0",
         "gaxios": "^2.1.0",
-        "gcp-metadata": "^3.2.0",
+        "gcp-metadata": "^3.3.0",
         "gtoken": "^4.1.0",
-        "jws": "^3.1.5",
+        "jws": "^4.0.0",
         "lru-cache": "^5.0.0"
       }
     },
     "google-p12-pem": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-2.0.3.tgz",
-      "integrity": "sha512-Tq2kBCANxYYPxaBpTgCpRfdoPs9+/lNzc/Iaee4kuMVW5ascD+HwhpBsTLwH85C9Ev4qfB8KKHmpPQYyD2vg2w==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-2.0.4.tgz",
+      "integrity": "sha512-S4blHBQWZRnEW44OcR7TL9WR+QCqByRvhNDZ/uuQfpxywfupikf/miba8js1jZi6ZOGv5slgSuoshCWh6EMDzg==",
       "requires": {
         "node-forge": "^0.9.0"
       }
@@ -2426,13 +2481,13 @@
       "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
     },
     "gtoken": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-4.1.3.tgz",
-      "integrity": "sha512-ofW+FiXjswyKdkjMcDbe6E4K7cDDdE82dGDhZIc++kUECqaE7MSErf6arJPAjcnYn1qxE1/Ti06qQuqgVusovQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-4.1.4.tgz",
+      "integrity": "sha512-VxirzD0SWoFUo5p8RDP8Jt2AGyOmyYcT/pOUgDKJCK+iSw0TMqwrVfY37RXTNmoKwrzmDHSk0GMT9FsgVmnVSA==",
       "requires": {
         "gaxios": "^2.1.0",
         "google-p12-pem": "^2.0.0",
-        "jws": "^3.1.5",
+        "jws": "^4.0.0",
         "mime": "^2.2.0"
       },
       "dependencies": {
@@ -2606,9 +2661,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
+          "integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -2637,21 +2692,26 @@
       }
     },
     "http-proxy-agent": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-      "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-3.0.0.tgz",
+      "integrity": "sha512-uGuJaBWQWDQCJI5ip0d/VTYZW0nRrlLWXA4A7P1jrsa+f77rW2yXz315oBt6zGCF6l8C2tlMxY7ffULCj+5FhA==",
       "requires": {
-        "agent-base": "4",
-        "debug": "3.1.0"
+        "agent-base": "5",
+        "debug": "4"
       },
       "dependencies": {
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -2666,18 +2726,18 @@
       }
     },
     "https-proxy-agent": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
-      "integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
+      "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
       "requires": {
-        "agent-base": "^4.3.0",
-        "debug": "^3.1.0"
+        "agent-base": "5",
+        "debug": "4"
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
           }
@@ -2804,6 +2864,11 @@
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
       "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
     },
+    "is-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.0.tgz",
+      "integrity": "sha512-t5mGUXC/xRheCK431ylNiSkGGpBp8bHENBcENTkDT6ppwPzEVxNGZRvgvmOEfbWkFhA7D2GEuE2mmQTr78sl2g=="
+    },
     "is-binary-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
@@ -2812,15 +2877,20 @@
         "binary-extensions": "^1.0.0"
       }
     },
+    "is-boolean-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.1.tgz",
+      "integrity": "sha512-TqZuVwa/sppcrhUCAYkGBk7w0yxfQQnxq28fjkO53tnK9FQXmdwz2JS5+GjsWQ6RByES1K40nI+yDic5c9/aAQ=="
+    },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-callable": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
     },
     "is-data-descriptor": {
       "version": "0.1.4",
@@ -2841,9 +2911,9 @@
       }
     },
     "is-date-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -2893,6 +2963,11 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-map": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.1.tgz",
+      "integrity": "sha512-T/S49scO8plUiAOA2DBTBG3JHpn1yiw0kRp6dgiZ0v2/6twi5eiB0rHtHFH9ZIrvlWc6+4O+m4zg5+Z833aXgw=="
+    },
     "is-number": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -2911,6 +2986,11 @@
         }
       }
     },
+    "is-number-object": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
+      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw=="
+    },
     "is-obj": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
@@ -2925,17 +3005,27 @@
       }
     },
     "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
       "requires": {
-        "has": "^1.0.1"
+        "has": "^1.0.3"
       }
+    },
+    "is-set": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.1.tgz",
+      "integrity": "sha512-eJEzOtVyenDs1TMzSQ3kU3K+E0GUS9sno+F0OBT97xsgcJsF9nXMBtkT9/kut5JEpM7oL7X/0qxR17K3mcwIAA=="
     },
     "is-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
       "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+    },
+    "is-string": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ=="
     },
     "is-symbol": {
       "version": "1.0.3",
@@ -2949,6 +3039,16 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "is-weakmap": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
+      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA=="
+    },
+    "is-weakset": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.1.tgz",
+      "integrity": "sha512-pi4vhbhVHGLxohUw7PhGsueT4vRGFoXhP7+RGN0jKIv9+8PWYCQTqtADngrxOm2g46hoH0+g8uZZBzMrvVGDmw=="
     },
     "is-windows": {
       "version": "1.0.2",
@@ -3002,6 +3102,11 @@
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-2.4.0.tgz",
           "integrity": "sha1-g4qZLan51zfg9LLbC+YrsJ3Qxeg="
+        },
+        "es6-promise": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+          "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
         }
       }
     },
@@ -3094,9 +3199,9 @@
       }
     },
     "jwa": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -3104,11 +3209,11 @@
       }
     },
     "jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
       "requires": {
-        "jwa": "^1.4.1",
+        "jwa": "^2.0.0",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -3118,9 +3223,9 @@
       "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s="
     },
     "kind-of": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
     },
     "klaw": {
       "version": "1.3.1",
@@ -3380,6 +3485,12 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
+    "memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "optional": true
+    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -3547,51 +3658,16 @@
       "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "mongodb": {
-      "version": "2.2.36",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.36.tgz",
-      "integrity": "sha512-P2SBLQ8Z0PVx71ngoXwo12+FiSfbNfGOClAao03/bant5DgLNkOPAck5IaJcEk4gKlQhDEURzfR3xuBG1/B+IA==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.5.2.tgz",
+      "integrity": "sha512-Lxt4th2tK2MxmkDBR5cMik+xEnkvhwg0BC5kGcHm9RBwaNEsrIryvV5istGXOHbnif5KslMpY1FbX6YbGJ/Trg==",
       "requires": {
-        "es6-promise": "3.2.1",
-        "mongodb-core": "2.1.20",
-        "readable-stream": "2.2.7"
-      },
-      "dependencies": {
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-        },
-        "readable-stream": {
-          "version": "2.2.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
-          "integrity": "sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE=",
-          "requires": {
-            "buffer-shims": "~1.0.0",
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~1.0.0",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
-    "mongodb-core": {
-      "version": "2.1.20",
-      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.20.tgz",
-      "integrity": "sha512-IN57CX5/Q1bhDq6ShAR6gIv4koFsZP7L8WOK1S0lR0pVDQaScffSMV5jxubLsmZ7J+UdqmykKw4r9hG3XQEGgQ==",
-      "requires": {
-        "bson": "~1.0.4",
-        "require_optional": "~1.0.0"
+        "bl": "^2.2.0",
+        "bson": "^1.1.1",
+        "denque": "^1.4.1",
+        "require_optional": "^1.0.1",
+        "safe-buffer": "^5.1.2",
+        "saslprep": "^1.0.0"
       }
     },
     "moog": {
@@ -3658,9 +3734,9 @@
       }
     },
     "mustache": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.1.0.tgz",
-      "integrity": "sha512-3Bxq1R5LBZp7fbFPZzFe5WN4s0q3+gxZaZuZVY+QctYJiCiVgXHOTIC0/HgZuOPFt/6BQcx5u0H2CUOxT/RoGQ=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.0.0.tgz",
+      "integrity": "sha512-FJgjyX/IVkbXBXYUwH+OYwQKqWpFPLaLVESd70yHjSDunwzV2hZOoTBvPf4KLoxesUzzyfTH6F784Uqd7Wm5yA=="
     },
     "mute-stream": {
       "version": "0.0.8",
@@ -3792,9 +3868,9 @@
       "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
     },
     "object-is": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
-      "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
+      "integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ=="
     },
     "object-keys": {
       "version": "1.1.1",
@@ -3809,13 +3885,15 @@
         "isobject": "^3.0.0"
       }
     },
-    "object.getownpropertydescriptors": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
-      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "requires": {
         "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.1"
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
       }
     },
     "object.pick": {
@@ -3892,9 +3970,9 @@
       }
     },
     "p-limit": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-      "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+      "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
       "requires": {
         "p-try": "^2.0.0"
       }
@@ -4116,9 +4194,9 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "postcss": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.24.tgz",
-      "integrity": "sha512-Xl0XvdNWg+CblAXzNvbSOUvgJXwSjmbAKORqyw9V2AlHrm1js2gFw9y3jibBAhpKZi8b5JzJCVh/FyzPsTtgTA==",
+      "version": "7.0.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
+      "integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
       "requires": {
         "chalk": "^2.4.2",
         "source-map": "^0.6.1",
@@ -4232,9 +4310,9 @@
           }
         },
         "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
+          "integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -4331,11 +4409,12 @@
       "integrity": "sha1-Hg9GUMhi3L/tVP1CsUjpuxch/PI="
     },
     "regexp.prototype.flags": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
-      "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
+      "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
       "requires": {
-        "define-properties": "^1.1.2"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
       }
     },
     "remove-trailing-separator": {
@@ -4424,9 +4503,9 @@
       }
     },
     "resolve": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.13.1.tgz",
-      "integrity": "sha512-CxqObCX8K8YtAhOBRg+lrcdn+LK+WYOS8tSjqSFbjtrI5PnS63QPhZl4+yKfrU9tdsbMu9Anr/amegT87M9Z6w==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.0.tgz",
+      "integrity": "sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==",
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -4510,9 +4589,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sanitize-html": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.20.1.tgz",
-      "integrity": "sha512-txnH8TQjaQvg2Q0HY06G6CDJLVYCpbnxrdO0WN8gjCKaU5J0KbyGYhZxx5QJg3WLZ1lB7XU9kDkfrCXUozqptA==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.21.1.tgz",
+      "integrity": "sha512-W6enXSVphVaVbmVbzVngBthR5f5sMmhq3EfPfBlzBzp2WnX8Rnk7NGpP7KmHUc0Y3MVk9tv/+CbpdHchX9ai7g==",
       "requires": {
         "chalk": "^2.4.1",
         "htmlparser2": "^3.10.0",
@@ -4524,6 +4603,15 @@
         "postcss": "^7.0.5",
         "srcset": "^1.0.0",
         "xtend": "^4.0.1"
+      }
+    },
+    "saslprep": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "optional": true,
+      "requires": {
+        "sparse-bitfield": "^3.0.3"
       }
     },
     "sax": {
@@ -4604,6 +4692,15 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+    },
+    "side-channel": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.2.tgz",
+      "integrity": "sha512-7rL9YlPHg7Ancea1S96Pa8/QWb4BtXL/TZvS6B8XFetGBeuhAsfmUspK6DokBeZ64+Kj9TCNRD/30pVz1BvQNA==",
+      "requires": {
+        "es-abstract": "^1.17.0-next.1",
+        "object-inspect": "^1.7.0"
+      }
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -4723,11 +4820,11 @@
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "source-map-resolve": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
-      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+      "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
       "requires": {
-        "atob": "^2.1.1",
+        "atob": "^2.1.2",
         "decode-uri-component": "^0.2.0",
         "resolve-url": "^0.2.1",
         "source-map-url": "^0.4.0",
@@ -4738,6 +4835,15 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+    },
+    "sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+      "optional": true,
+      "requires": {
+        "memory-pager": "^1.0.2"
+      }
     },
     "split-string": {
       "version": "3.1.0",
@@ -4848,18 +4954,18 @@
       }
     },
     "string.prototype.trimleft": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
-      "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
+      "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
       "requires": {
         "define-properties": "^1.1.3",
         "function-bind": "^1.1.1"
       }
     },
     "string.prototype.trimright": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
-      "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
+      "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
       "requires": {
         "define-properties": "^1.1.3",
         "function-bind": "^1.1.1"
@@ -4917,12 +5023,12 @@
       }
     },
     "teeny-request": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-5.3.2.tgz",
-      "integrity": "sha512-5cse2cocD8Drq0uYN7NPcQ/6qbrxH6Kp0TlNLP+Y5f0twEkGtIg0ti8HoYF2LCC2TO5IkK/I9/Xs38/rDvs5UA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-6.0.0.tgz",
+      "integrity": "sha512-S7EOZ3RHbjaiPHheg0kybDi5X8RGO1e/Hm7Wk7exhXkkNXI89p/bKbbgQRt7gZR5EPzmdvFN4Yr/6i22bCnSfA==",
       "requires": {
-        "http-proxy-agent": "^2.1.0",
-        "https-proxy-agent": "^3.0.0",
+        "http-proxy-agent": "^3.0.0",
+        "https-proxy-agent": "^4.0.0",
         "node-fetch": "^2.2.0",
         "stream-events": "^1.0.5",
         "uuid": "^3.3.2"
@@ -5108,9 +5214,9 @@
       }
     },
     "underscore": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.2.tgz",
+      "integrity": "sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ=="
     },
     "underscore.string": {
       "version": "3.3.5",
@@ -5218,11 +5324,6 @@
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         },
-        "es6-promise": {
-          "version": "4.2.8",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-          "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
-        },
         "mkdirp": {
           "version": "0.3.5",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
@@ -5282,15 +5383,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
-    "util.promisify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
-      "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
-      "requires": {
-        "define-properties": "^1.1.2",
-        "object.getownpropertydescriptors": "^2.0.3"
-      }
-    },
     "utile": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
@@ -5347,6 +5439,29 @@
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "requires": {
         "isexe": "^2.0.0"
+      }
+    },
+    "which-boxed-primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.1.tgz",
+      "integrity": "sha512-7BT4TwISdDGBgaemWU0N0OU7FeAEJ9Oo2P1PHRm/FCWoEi2VLWC9b6xvxAA3C/NMpxg3HXVgi0sMmGbNUbNepQ==",
+      "requires": {
+        "is-bigint": "^1.0.0",
+        "is-boolean-object": "^1.0.0",
+        "is-number-object": "^1.0.3",
+        "is-string": "^1.0.4",
+        "is-symbol": "^1.0.2"
+      }
+    },
+    "which-collection": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.0.tgz",
+      "integrity": "sha512-mG4RtFHE+17N2AxRNvBQ488oBjrhaOaI/G+soUaRJwdyDbu5zmqoAKPYBlY7Zd+QTwpfvInRLKo40feo2si1yA==",
+      "requires": {
+        "is-map": "^2.0.0",
+        "is-set": "^2.0.0",
+        "is-weakmap": "^2.0.0",
+        "is-weakset": "^2.0.0"
       }
     },
     "window-size": {
@@ -5437,12 +5552,11 @@
       "integrity": "sha1-qQKekp09vN7RafPG4oI42VpdWig="
     },
     "xml2js": {
-      "version": "0.4.22",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.22.tgz",
-      "integrity": "sha512-MWTbxAQqclRSTnehWWe5nMKzI3VmJ8ltiJEco8akcC6j3miOhjjfzKum5sId+CWhfxdOs/1xauYr8/ZDBtQiRw==",
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
       "requires": {
         "sax": ">=0.6.0",
-        "util.promisify": "~1.0.0",
         "xmlbuilder": "~11.0.0"
       }
     },

--- a/_api-reference-generator/package.json
+++ b/_api-reference-generator/package.json
@@ -13,7 +13,7 @@
     "apostrophe": "^2.100.2",
     "async": "^2.6.3",
     "boring": "^0.1.0",
-    "glob": "^7.1.4",
+    "glob": "^7.1.6",
     "js-tokenizer": "^1.3.3",
     "lodash": "^4.17.15",
     "mkdirp": "^0.5.1",

--- a/modules/README.md
+++ b/modules/README.md
@@ -10,17 +10,17 @@ Modules are implemented as [moog types](../other/glossary.md#moog-type), which p
 
 For convenience, the `apostrophe` npm module contains all of the "core" Apostrophe modules that are necessary for a functioning website.
 
-Some of these, like [apostrophe-docs](apostrophe-docs/README.md), are initialized every time Apostrophe starts up; you can [see that list on github](https://github.com/punkave/apostrophe/blob/master/defaults.js). Those modules are initialized first, followed by those you configure in `app.js`, in the order you configure them.
+Some of these, like [apostrophe-docs](apostrophe-docs/README.md), are initialized every time Apostrophe starts up; you can [see that list on github](https://github.com/apostrophecms/apostrophe/blob/master/defaults.js). Those modules are initialized first, followed by those you configure in `app.js`, in the order you configure them.
 
 Others, like [apostrophe-pieces](apostrophe-pieces/README.md) and [apostrophe-widgets](apostrophe-widgets/README.md), are "abstract base classes" you can extend to create new modules that provide content types.
 
 [apostrophe-module](apostrophe-module/README.md) is the base class of **all** modules; it provides features that are convenient in almost any module, like [rendering a template from its `views` folder](apostrophe-module/README.md#render), or [pushing assets from its `public` folder](apostrophe-module/README.md#push-asset).
 
-Modules can also be installed via npm, and multiple Apostrophe modules can be [shipped as a single npm module via moog bundles](/tutorials/getting-started/core-concepts/modules/more-modules.md).
+Modules can also be installed via npm, and multiple Apostrophe modules can be [shipped as a single npm module via moog bundles](../more-modules.md).
 
 ## Overriding, configuring and extending modules at "project level"
 
-Any options you provide for a module via the `modules` property in `app.js` override the default configuration for a module, as seen in the [tutorials](/README.md). And any configuration provided via the `modules` property in `data/local.js` overrides that, allowing for server-specific settings like API keys.
+Any options you provide for a module via the `modules` property in `app.js` override the default configuration for a module, as seen in the [tutorials](../tutorials/README.md). And any configuration provided via the `modules` property in `data/local.js` overrides that, allowing for server-specific settings like API keys.
 
 You can also provide your own templates in the `lib/modules/module-name/views` folder of your project (**not** in `node_modules`) to override the templates of `module-name`, and provide your own code in `lib/modules/module-name/index.js` to override methods and add functionality. *If your project-level `lib/modules` folder has a module by the same name as a core or npm module, any code you provide automatically subclasses and improves that module.*
 

--- a/modules/apostrophe-admin-bar/README.md
+++ b/modules/apostrophe-admin-bar/README.md
@@ -3,7 +3,7 @@
 The admin bar module implements Apostrophe's admin bar at the top of the screen. Any module
 can register a button (or more than one) for this bar by calling the `add` method of this
 module. Buttons can also be grouped into dropdown menus and restricted to those with
-particular permissions. [apostrophe-pieces](../apostrophe-pieces/README.md) automatically
+particular permissions. [apostrophe-pieces](/tutorials/core-concepts/reusable-content-pieces/README.md) automatically
 takes advantage of this module.
 
 The admin bar slides out on all pages by default. It's possible to modify this behavior

--- a/modules/apostrophe-admin-bar/browser-apostrophe-admin-bar.md
+++ b/modules/apostrophe-admin-bar/browser-apostrophe-admin-bar.md
@@ -7,3 +7,5 @@ Implement the admin bar's toggle behavior and graceful close of dropdowns at
 appropriate times.
 ### collapse(*$bar*)
 
+### autoCollapse(*$bar*)
+

--- a/modules/apostrophe-any-page-manager/README.md
+++ b/modules/apostrophe-any-page-manager/README.md
@@ -1,7 +1,7 @@
 ## Inherits from: [apostrophe-doc-type-manager](../apostrophe-doc-type-manager/README.md)
 This module provides a special doc type manager for the `apostrophe-page` type, which
 actually refers to any page in the tree, regardless of type. This
-allows you to create [apostrophe-schemas](../apostrophe-schemas/README.md) that can link to
+allows you to create [apostrophe-schemas](/tutorials/schema-guide/schema-guide) that can link to
 any page in the page tree, rather than one specific page type.
 
 

--- a/modules/apostrophe-areas/README.md
+++ b/modules/apostrophe-areas/README.md
@@ -127,6 +127,9 @@ Very handy for imports of all kinds: convert plaintext to an area with
 one `apostrophe-rich-text` widget if it is not blank, otherwise an empty area. null and
 undefined are tolerated and converted to empty areas.
 Takes an option `el` if you wish to specify a wrapper element. Ex: `fromPlaintext(text, { el: 'p' })`.
+### fromRichText(*html*) *[api]*
+Convert HTML to an area with one 'apostrophe-rich-text' widget, otherwise
+an empty area. null and undefined are tolerated and converted to empty areas.
 ### modulesReady() *[api]*
 When all modules are ready and all widget managers therefore should have been
 added, determine the list of rich text widgets for purposes of the

--- a/modules/apostrophe-areas/README.md
+++ b/modules/apostrophe-areas/README.md
@@ -175,6 +175,8 @@ If the field type has a `copy` method it is used.
 Otherwise, custom logic handles `join` fields, and
 the rest are copied by simple assignment to the
 named field.
+### editVirtualArea(*req*, *items*, *options*, *callback*) *[routes]*
+Implementation detail of the `edit-virtual-area` and `edit-virtual-areas` routes.
 ### pageBeforeSend(*req*) *[browser]*
 
 ### getCreateSingletonOptions(*req*) *[browser]*
@@ -293,4 +295,5 @@ An area is empty if it has no widgets in it, or when
 all of the widgets in it return true when their
 `isEmpty()` methods are interrogated. For instance,
 if an area only contains a rich text widget and that
-widget. A widget with no `isEmpty()` method is never empty.
+widget contains no markup or text, this function will
+return true. A widget with no `isEmpty()` method is never empty.

--- a/modules/apostrophe-areas/browser-apostrophe-areas-editor.md
+++ b/modules/apostrophe-areas/browser-apostrophe-areas-editor.md
@@ -57,16 +57,7 @@ Disable area controls interactions while certain menus are open
 Implementation detail of `addItem`, should not be called directly.
 Adds the given widget wrapper to the DOM, respecting the limit.
 ### fixInsertedWidgetDotPaths(*$widget*)
-A newly inserted widget that contains subareas cannot autosave
-correctly as part of the parent unless its doc id and
-dot path are correctly set to show that relationship. But
-render-widget has no way of knowing how to set these for us,
-plus all the widgets below it now have dotPaths that are off
-by one. Fix the whole mess
-### recalculateDotPathsInArea(*$area*)
-
-### recalculateDotPathsOfAreasInWidget(*$widget*, *docId*, *dotPath*)
-
+Legacy, kept for bc, we now call remapDotPaths at a better time
 ### enhanceWidgetControls(*$widget*)
 
 ### addAreaControls(*$widget*)

--- a/modules/apostrophe-areas/browser-apostrophe-areas-editor.md
+++ b/modules/apostrophe-areas/browser-apostrophe-areas-editor.md
@@ -47,6 +47,8 @@ Disable area controls interactions while certain menus are open
 
 ### dismissContextContentMenu()
 
+### dismissContextContentMenuKeyEvent(*e*)
+
 ### linkWidgetsToAreaEditor()
 
 ### removeInitialContent(*$el*, *entireItem*)

--- a/modules/apostrophe-areas/browser-apostrophe-areas.md
+++ b/modules/apostrophe-areas/browser-apostrophe-areas.md
@@ -46,6 +46,14 @@ and reveals only the controls on the directly hovered widget, not the parent wra
 ### enableAll(*sel*)
 Enable the areas in the specified selector or jQuery object to be edited.
 If sel is falsy all areas currently in the body are made editable
+### register(*docId*, *dotPath*, *editor*)
+
+### remapDotPaths()
+
+### recalculateDotPathsInArea(*$area*)
+
+### recalculateDotPathsOfAreasInWidget(*$widget*, *docId*, *dotPath*)
+
 ### enableShift()
 
 ### getWidgetOptions(*$widget*)

--- a/modules/apostrophe-assets/README.md
+++ b/modules/apostrophe-assets/README.md
@@ -68,7 +68,7 @@ Example:
 
 If explicitly set to `false`, the mechanism that otherwise removes stale
 uploadfs static asset bundles five minutes after launch is disabled.
-See [Deploying Apostrophe in the Cloud with Heroku](https://docs.apostrophecms.org/apostrophe/tutorials/howtos/deploying-apostrophe-in-the-cloud-with-heroku)
+See [Deploying Apostrophe in the Cloud with Heroku](/tutorials/devops/deployment/deploying-apostrophe-in-the-cloud-with-heroku)
 for more information.
 
 ## Additional Environment Variables
@@ -95,7 +95,7 @@ Legacy. For use when `APOS_BUNDLE` is set to an explicit bundle name but you sti
 generated to reference those files via uploadfs. But this is the hard way; just run `apostrophe:generation` with
 APOS_BUNDLE=1, and also set `APOS_BUNDLE=1` in the environment when launching Apostrophe. That's really all you
 have to do.
-See [Deploying Apostrophe in the Cloud with Heroku](https://docs.apostrophecms.org/apostrophe/tutorials/howtos/deploying-apostrophe-in-the-cloud-with-heroku) for more information.
+See [Deploying Apostrophe in the Cloud with Heroku](/tutorials/devops/deployment/howtos/deploying-apostrophe-in-the-cloud-with-heroku) for more information.
 
 ### `APOS_BUNDLE_CLEANUP_DELAY`
 
@@ -104,7 +104,7 @@ cleaning up obsolete static asset bundles in uploadfs. The default
 is 5 minutes. The assumption is that all production servers have received
 the new deployment and finished serving any straggler HTTP requests 5 minutes after
 a new version is first launched.
-See [Deploying Apostrophe in the Cloud with Heroku](https://docs.apostrophecms.org/apostrophe/tutorials/howtos/deploying-apostrophe-in-the-cloud-with-heroku)
+See [Deploying Apostrophe in the Cloud with Heroku](/tutorials/devops/deployment/deploying-apostrophe-in-the-cloud-with-heroku)
 for more information.
 
 
@@ -261,6 +261,8 @@ return an array of copies that must be performed, with `from`
 and `to` properties
 ### buildLessMasters(*callback*)
 
+### getStylesheetsMasterBase()
+
 ### minify(*callback*)
 
 ### outputAndBless(*callback*)
@@ -356,6 +358,16 @@ Override point to use a separate uploadfs instance, for
 instance in a multisite project with shared assets
 ### pushCreateSingleton()
 
+### getGenerationPath()
+
+### getThemedGeneration()
+
+### getThemed(*s*)
+
+### getThemeName()
+Can be overridden by modules like apostrophe-multisite
+to namespace minified asset bundles and LESS masters.
+Env var option is for unit testing only
 ## Nunjucks template helpers
 ### stylesheets(*when*)
 apos.assets.stylesheets renders markup to load CSS that

--- a/modules/apostrophe-attachments/README.md
+++ b/modules/apostrophe-attachments/README.md
@@ -3,7 +3,7 @@
 This module implements the
 [attachment](https://docs.apostrophecms.org/apostrophe/tutorials/getting-started/schema-guide#attachment) schema field type,
 which makes it straightforward to allow users to attach uploaded files to docs. See
-the [schema guide](https://docs.apostrophecms.org/apostrophe/tutorials/getting-started/schema-guide#attachment) for
+the [schema guide](/tutorials/schema-guide/schema-guide#attachment) for
 more information.
 
 ## Options

--- a/modules/apostrophe-attachments/browser-apostrophe-attachments.md
+++ b/modules/apostrophe-attachments/browser-apostrophe-attachments.md
@@ -31,6 +31,8 @@ is up to you.
 
 ### convert(*data*, *name*, *$field*, *$el*, *field*, *callback*)
 
+### autocrop(*field*, *attachment*, *callback*)
+
 ### addHandlers()
 
 ### updateExisting(*$fieldset*, *info*, *field*)

--- a/modules/apostrophe-browser-utils/README.md
+++ b/modules/apostrophe-browser-utils/README.md
@@ -1,6 +1,6 @@
 ## Inherits from: [apostrophe-module](../apostrophe-module/README.md)
 Pushes utility methods to the browser as the `apos.utils` singleton. This module
-is separate from [apostrophe-utils](https://docs.apostrophecms.org/apostrophe/modules/apostrophe-utils) because that
+is separate from [apostrophe-utils](/modules/apostrophe-utils) because that
 module is initialized very early, before it is possible to push assets to the browser.
 
 

--- a/modules/apostrophe-csrf/README.md
+++ b/modules/apostrophe-csrf/README.md
@@ -1,2 +1,5 @@
 ## Inherits from: [apostrophe-module](../apostrophe-module/README.md)
 
+## Methods
+### enableMiddleware()
+

--- a/modules/apostrophe-custom-pages/README.md
+++ b/modules/apostrophe-custom-pages/README.md
@@ -4,7 +4,7 @@ Extra fields can be added to the page settings modal in the usual way via
 the `addFields` option, and Express-style routes can be added to handle
 URLs that extend beyond the slug of the page using the `dispatch` method.
 
-The [apostrophe-pieces-pages](https://docs.apostrophecms.org/apostrophe/modules/apostrophe-pieces-pages) module
+The [apostrophe-pieces-pages](/modules/apostrophe-pieces-pages) module
 is a good example of a subclass of this module.
 
 ## Options

--- a/modules/apostrophe-db/README.md
+++ b/modules/apostrophe-db/README.md
@@ -24,14 +24,8 @@ PLEASE NOTE: this will drop collections UNRELATED to apostrophe.
 If that is a concern for you, drop Apostrophe's collections yourself
 and start up your app, which will recreate them.
 ### bcPatch()
-Makes a `findWithProjection` method available on all collections,
-which is just an alias for `find` because the MongoDB 2.x driver
-already allows a projection as the second argument. This is useful
-because the `apostrophe-db-mongo-3-driver` module provides the
-same method while allowing you to use the newer MongoDB 3.x driver.
-All existing Apostrophe code that directly calls MongoDB's `find()`
-is being migrated to use `findWithProjection` for forwards and
-backwards compatibility.
+Just a bc wrapper now that we are using emulate-mongo-2-driver,
+which already adds findWithProjection as a synonym.
 ### resetFromTask(*callback*)
 
 ### dropAllCollections(*callback*)

--- a/modules/apostrophe-doc-type-manager/README.md
+++ b/modules/apostrophe-doc-type-manager/README.md
@@ -22,7 +22,7 @@ continue to manage it.)
 
 ### Schema options
 The standard schema options, including `addFields`, `removeFields` and `arrangeFields`.
-See the [schema guide](https://docs.apostrophecms.org/apostrophe/tutorials/getting-started/schema-guide).
+See the [schema guide](/tutorials/schema-guide/schema-guide).
 
 
 ## Methods

--- a/modules/apostrophe-doc-type-manager/browser-apostrophe-doc-type-manager-chooser.md
+++ b/modules/apostrophe-doc-type-manager/browser-apostrophe-doc-type-manager-chooser.md
@@ -28,6 +28,8 @@ label and value properties at a minimum
 
 ### enableAutocomplete()
 
+### enableSortable()
+
 ### getBrowserType()
 
 ### launchBrowser()

--- a/modules/apostrophe-docs/README.md
+++ b/modules/apostrophe-docs/README.md
@@ -8,7 +8,7 @@ that manages a particular doc type, so that you can benefit from behavior
 specific to that module. One method of this module that you may sometimes use directly
 is `apos.docs.find()`, which returns a [cursor](https://docs.apostrophecms.org/apostrophe/modules/apostrophe-docs/server-apostrophe-cursor) for
 fetching documents of all types. This is useful when implementing something
-like the [apostrophe-search](https://docs.apostrophecms.org/apostrophe/modules/apostrophe-search) module.
+like the [apostrophe-search](/modules/apostrophe-search) module.
 
 ## Options
 

--- a/modules/apostrophe-email/README.md
+++ b/modules/apostrophe-email/README.md
@@ -6,8 +6,14 @@ Implements the `email` method available in all modules.
 
 See `apostrophe-module` for coverage of the `email` method that
 every module has. You won't need to call `emailForModule` directly.
-### getTransport()
-Fetch the nodemailer-compatible transport object. The default
+### getContent(*req*, *templateName*, *data*, *options*, *module*)
+Compute the content of the email. This is an interesting override point
+to add properties that will be passed to nodemailer transport when
+sending the email.
+### getTransport(*req*, *data*, *options*)
+Fetch the nodemailer-compatible transport object, that is going to be
+used to send the email. It may be a convenient override point to decide
+which transport to use according to the parameters passed. The default
 implementation creates a transport via `nodemailer.createTransport`
 on the first call, passing it the value of the `nodemailer` option
 configured for the `apostrophe-email` module. If there is none,

--- a/modules/apostrophe-express/README.md
+++ b/modules/apostrophe-express/README.md
@@ -5,7 +5,7 @@ The Express `app` object is made available as `apos.app`, and
 the `express` object itself as `apos.express`. You can add
 Express routes directly in your modules via `apos.app.get`,
 `apos.app.post`, etc., however be sure to also check
-out the [route method](https://docs.apostrophecms.org/apostrophe/modules/apostrophe-module#route-method-path-fn) available
+out the [route method](/modules/apostrophe-module#route-method-path-fn) available
 in all modules for a cleaner way to implement API routes. Adding
 routes directly to the Express app object is still sometimes useful when
 the URLs will be public.
@@ -185,7 +185,7 @@ to the `apos.middleware` object for your use where appropriate:
 This middleware function accepts file uploads and makes them
 available via `req.files`. See the
 [connect-multiparty](https://npmjs.org/package/connect-multiparty) npm module.
-This middleware is used by [apostrophe-attachments](https://docs.apostrophecms.org/apostrophe/modules/apostrophe-attachments).
+This middleware is used by [apostrophe-attachments](/modules/apostrophe-attachments).
 
 ## Module-specific middleware
 
@@ -199,6 +199,13 @@ If `expressMiddleware` is a non-array object, it must have a `middleware`
 property containing a function or an array of functions, and it may also have a
 `before` property containing the name of another module. The function(s) in the
 `middleware` property will be run before those for the named module.
+
+If you need to run the middleware very early, the object may also have a
+`when` property, which may be set to `beforeRequired` (the absolute
+beginning, before even req.body is available), `afterRequired` (after all
+middleware shipped with apostrophe-express but before all middleware passed
+to it as options), or `afterConfigured` (the default, with other module
+middleware).
 
 
 ## Methods

--- a/modules/apostrophe-files-widgets/README.md
+++ b/modules/apostrophe-files-widgets/README.md
@@ -1,5 +1,5 @@
 ## Inherits from: [apostrophe-pieces-widgets](../apostrophe-pieces-widgets/README.md)
 Provides widgets for downloading PDF files and other files that have been
-uploaded to the file library provided by [apostrophe-files](https://docs.apostrophecms.org/apostrophe/modules/apostrophe-files).
+uploaded to the file library provided by [apostrophe-files](/modules/apostrophe-files).
 
 

--- a/modules/apostrophe-files/README.md
+++ b/modules/apostrophe-files/README.md
@@ -1,3 +1,6 @@
 ## Inherits from: [apostrophe-pieces](../apostrophe-pieces/README.md)
 ### `apos.files`
 
+## Methods
+### addUrls(*req*, *files*, *callback*)
+

--- a/modules/apostrophe-groups/README.md
+++ b/modules/apostrophe-groups/README.md
@@ -1,6 +1,6 @@
 ## Inherits from: [apostrophe-pieces](../apostrophe-pieces/README.md)
 ### `apos.groups`
-Provide a way to group [apostrophe-users](https://docs.apostrophecms.org/apostrophe/modules/apostrophe-users) together
+Provide a way to group [apostrophe-users](/modules/apostrophe-users) together
 and assign permissions to them. This module is always active "under the hood," even if
 you take advantage of the `groups` option of `apostrophe-users` to skip a separate
 admin bar button for managing groups. **To make an admin bar button available

--- a/modules/apostrophe-images-widgets/README.md
+++ b/modules/apostrophe-images-widgets/README.md
@@ -1,7 +1,8 @@
 ## Inherits from: [apostrophe-pieces-widgets](../apostrophe-pieces-widgets/README.md)
 Implements widgets that display single images and slideshows.
 
-See [adding editable content to pages](https://docs.apostrophecms.org/apostrophe/tutorials/getting-started/adding-editable-content-to-pages#apostrophe-images) for a thorough discussion of the options that can be passed to the widget.
+See [adding editable content to pages](/tutorials/editable-content-on-pages/standard-widgets#apostrophe-images) for a thorough discussion of the options that can be passed to the widget.
+
 
 ## Methods
 ### pushAssets()

--- a/modules/apostrophe-images/README.md
+++ b/modules/apostrophe-images/README.md
@@ -3,12 +3,12 @@
 A subclass of `apostrophe-pieces`, `apostrophe-images` establishes a library
 of uploaded images in formats suitable for use on the web.
 
-Together with [apostrophe-images-widgets](https://docs.apostrophecms.org/apostrophe/modules/apostrophe-images-widgets),
+Together with [apostrophe-images-widgets](/modules/apostrophe-images-widgets),
 this module provides a simple way to add downloadable PDFs and the like to
 a website, and to manage a library of them for reuse.
 
 Each `apostrophe-image` doc has an `attachment` schema field, implemented
-by the [apostrophe-attachments](https://docs.apostrophecms.org/apostrophe/modules/apostrophe-images-widgets) module.
+by the [apostrophe-attachments](/modules/apostrophe-images-widgets) module.
 
 
 ## Methods

--- a/modules/apostrophe-login/README.md
+++ b/modules/apostrophe-login/README.md
@@ -12,10 +12,50 @@ This usually makes sense only in the presence of an alternative such as
 the `apostrophe-passport` module, which adds support for login via
 Google, Twitter, gitlab, etc.
 
+`passwordMinLength`
+
+The minimum length for passwords. You should set this, as there
+is no default for bc reasons (effectively the default is `1`).
+
+`passwordRules`
+
+An optional array of password rule names, as strings. The standard rules
+available are `noSlashes`, `noSpaces`, `mixedCase`, `digits`, and
+`noTripleRepeats`. The `noTripleRepeats` rule forbids repeating a
+character three times in a row. By default no rules are in effect.
+
+When this option is set, the rules are consulted when a password
+is set or reset. Existing passwords that do not follow the rules
+are tolerated. If you wish to enforce them for existing passwords
+as well, see below.
+
+`resetLegacyPassword`
+
+By default, password rules are enforced only when a password is
+being set or reset. If you wish, you can set `resetLegacyPassword: true`
+to require users to reset their password on the spot if it is
+correct but does not meet the current rules. However if you are able
+to enable the email-based `passwordReset: true` option that
+is slightly more secure because it requires proof of ownership of the
+email address as well as the old password. You can combine that with
+`passwordRulesAtLoginTime`, below.
+
+`passwordRulesAtLoginTime`
+
+By default, password rules are enforced only when a password is
+being set or reset. Setting this option to `true` will apply
+the rules at login time, so that even an existing password will
+not work unless it passes the rules. This can be useful if you don't
+mind a few irritated users and you have enabled
+the email-based `passwordReset: true`. However this requires
+email delivery to work (see below), so you may be more comfortable
+with `resetLegacyPassword: true` (above).
+
 `passwordReset`
 
 If set to `true`, the user is given the option to reset their password,
 provided they can receive a confirmation email. Not available if `localLogin` is `false`.
+Email delivery must work, which requires more configuration; see [sending email with ApostropheCMS](https://docs.apostrophecms.org/apostrophe/tutorials/howtos/email).
 
 `passwordResetHours`
 
@@ -23,6 +63,14 @@ When `passwordReset` is `true`, this option controls how many hours
 a password reset request remains valid. If the confirmation email is not
 acted upon in time, the user must request a password reset again.
 The default is `48`.
+
+`resetKnownPassword`
+
+This option allows the user to change their password, provided they know
+their current password. This is helpful, but it does not help uers who have
+forgotten their passwords. For that, you should enable `passwordReset`
+(see above for concerns). You should bear in mind that this option is not as
+secure as requiring confirmation via email with `passwordReset.
 
 ## Notable properties of apos.modules['apostrophe-login']
 
@@ -43,10 +91,14 @@ is invoked with `req` and may also optionally take a callback.
 ### enableSerializeUsers()
 Set the `serializeUser` method of `passport` to serialize the
 user by storing their user ID in the session.
+### randomKey(*len*)
+
+### getRandomInt(*min*, *max*)
+
 ### enableDeserializeUsers()
 Set the `deserializeUser` method of `passport` to
 deserialize the user by locating the appropriate
-user via the [apostrophe-users](https://docs.apostrophecms.org/apostrophe/modules/apostrophe-users)
+user via the [apostrophe-users](/modules/apostrophe-users)
 module. Then invokes the `loginDeserialize` method of
 every module that has one, passing the `user` object. These
 methods may optionally take a callback.
@@ -82,11 +134,13 @@ types that are not restricted to admins only.
 ### enableLocalStrategy()
 Adds the "local strategy" (username/email and password login)
 to Passport. Users are found via the `find` method of the
-[apostrophe-users](https://docs.apostrophecms.org/apostrophe/modules/apostrophe-users) module.
+[apostrophe-users](/modules/apostrophe-users) module.
 Users with the `disabled` property set to true may not log in.
 Passwords are verified via the `verifyPassword` method of
-[apostrophe-users](https://docs.apostrophecms.org/apostrophe/modules/apostrophe-users), which is
+[apostrophe-users](/modules/apostrophe-users), which is
 powered by the [credential](https://npmjs.org/package/credential) module.
+### enableTotp()
+
 ### verifyLogin(*username*, *password*, *callback*)
 Verify a login attempt. `username` can be either
 the username or the email address (both are unique).
@@ -107,11 +161,16 @@ argument. You MUST check the second argument.
 
 The convention is set this way for compatibility
 with `passport`.
+### verifyTotp(*user*, *done*)
+
 ### enableMiddleware()
 Add Passport's initialize and session middleware.
 Also add middleware to add the `req.data.user` property.
 Now works via the expressMiddleware property, allowing
 control of timing relative to other modules.
+### requireTotp(*req*, *res*, *next*)
+If the user is logged in, require that they also have
+totp, otherwise kick them over to get it
 ### addRoutes()
 Add the `/login` route, both GET (show the form) and POST (submit the form).
 Also add the `/logout` route.
@@ -131,10 +190,26 @@ Add the `user` property to `req.data` when a user is logged in.
 Push the login stylesheet.
 ### addAdminBarItems()
 Add the logout admin bar item.
+### addAdminBarItems()
+
 ### afterLogin(*req*, *res*)
 Invoked by passport after an authentication strategy succeeds
 and the user has been logged in. Invokes `loginAfterLogin` on
 any modules that have one and redirects to `req.redirect` or,
 if it is not set, to `/`.
+### checkPasswordRules(*req*, *password*)
+Returns an array of error messages, which will be
+empty if there are no errors. The error messages
+will be internationalized for you.
+### addPasswordRule(*name*, *test*, *message*)
+Register a password validation rule. Does not
+activate it, see the passwordRules option.
+`name` is a unique name to be included in the
+`passwordRules` option array, `test` is a function
+that accepts the password and returns `true` only
+if the password passes the rule, and `message`
+is a short message to be shown to the user in the
+event the rule fails, which will automatically be
+internationalized for you.
 ### modulesReady()
 

--- a/modules/apostrophe-module/README.md
+++ b/modules/apostrophe-module/README.md
@@ -118,6 +118,12 @@ If you require additional properties for the JSON object sent
 for an error, you can pass an object containing them as the
 third argument to `next`. This is separate from the success value
 to avoid accidentally disclosing information on errors.
+
+In addition, if `req.errorMessages` is set, it is
+passed as the `messages` property of the JSON object.
+This is a helpful way to accommodate percolating detailed
+error messages up from a nested function call through a
+stack that otherwise only accommodates simple string errors.
 ### htmlRoute(*method*, *path*, *fn*)
 Similar to `route`, except that the route function receives
 (req, res, next), and you may pass `next` either an error or

--- a/modules/apostrophe-pages/README.md
+++ b/modules/apostrophe-pages/README.md
@@ -122,7 +122,7 @@ publishMenu: [
 Again, you can override it by setting `req.publishMenu`.
 
 If you are looking for the schema fields common to all pages in the tree,
-check out the [apostrophe-custom-pages](https://docs.apostrophecms.org/apostrophe/modules/apostrophe-custom-pages)
+check out the [apostrophe-custom-pages](/modules/apostrophe-custom-pages)
 module, which all page types extend, including "ordinary" pages.
 
 ### `park`
@@ -206,7 +206,7 @@ and an `_ancestors` property:
 };
 ```
 
-See the [apostrophe-pages-cursor](https://docs.apostrophecms.org/apostrophe/modules/apostrophe-pages/server-apostrophe-pages-cursor) type for additional
+See the [apostrophe-pages-cursor](/modules/apostrophe-pages/server-apostrophe-pages-cursor) type for additional
 cursor filters and options you might wish to configure, such as adding
 a `depth` option to `children`.
 
@@ -310,7 +310,7 @@ is also a one-time action, so the setting itself is cleared afterwards by this m
 This method is called for us by the apostrophe-docs module on update
 operations, so we first make sure it's a page. We also make sure it's
 not a new page (no kids to propagate anything to).
-### newChild(*parentPage*) *[api]*
+### newChild(*parentPage*, *type*) *[api]*
 This method creates a new object suitable to be inserted
 as a child of the specified parent via insert(). It DOES NOT
 insert it at this time. If the parent page is locked down

--- a/modules/apostrophe-pieces-pages/README.md
+++ b/modules/apostrophe-pieces-pages/README.md
@@ -9,7 +9,7 @@ that extend `apostrophe-pieces`.
 
 To learn more and see complete examples, see:
 
-[Reusable content with pieces](https://docs.apostrophecms.org/apostrophe/tutorials/getting-started/reusable-content-with-pieces)
+[Reusable content with pieces](/tutorials/core-concepts/reusable-content-pieces)
 
 ## Options
 
@@ -59,7 +59,7 @@ the index view via `indexPage`; if the URL has an additional component,
 e.g. `/blog/good-article`, it is assumed to be the slug of the
 article and `showPage` is invoked. You can override this method,
 for instance to also accept `/:year/:month/:day/:slug` as a way of
-invoking `self.showPage`. See [apostrophe-custom-pages](https://docs.apostrophecms.org/apostrophe/modules/apostrophe-custom-pages)
+invoking `self.showPage`. See [apostrophe-custom-pages](/modules/apostrophe-custom-pages)
 for more about what you can do with dispatch routes.
 ### chooseParentPage(*pages*, *piece*)
 Given an array containing all of the index pages of this type that
@@ -89,7 +89,7 @@ in the browser
 Adds the `._url` property to all of the provided pieces,
 which are assumed to be of the appropriate type for this module.
 Aliased as the `addUrls` method of [apostrophe-pieces](https://docs.apostrophecms.org/apostrophe/modules/apostrophe-pieces), which
-is invoked by the `addUrls` filter of [apostrophe-cursor](https://docs.apostrophecms.org/apostrophe/modules/apostrophe-docs/server-apostrophe-cursor).
+is invoked by the `addUrls` filter of [apostrophe-cursor](/modules/apostrophe-docs/server-apostrophe-cursor).
 ### findForAddUrlsToPieces(*req*)
 Returns a cursor suitable for finding pieces-pages for the
 purposes of assigning URLs to pieces based on the best match.

--- a/modules/apostrophe-pieces-widgets/README.md
+++ b/modules/apostrophe-pieces-widgets/README.md
@@ -7,7 +7,7 @@ that extend `apostrophe-pieces`.
 
 To learn more and see complete examples, see:
 
-[Reusable content with pieces](https://docs.apostrophecms.org/apostrophe/tutorials/getting-started/reusable-content-with-pieces)
+[Reusable content with pieces](/tutorials/getting-started/core-concepts/reusable-content-pieces)
 
 ## options
 

--- a/modules/apostrophe-pieces/README.md
+++ b/modules/apostrophe-pieces/README.md
@@ -6,7 +6,7 @@ you'll get a user interface for managing your content for free. Add in the
 for your pieces, and use `apostrophe-pieces-widgets` to allow them to be sprinkled
 into pages all over the site. To learn more, see:
 
-[Reusable content with pieces](https://docs.apostrophecms.org/apostrophe/tutorials/getting-started/reusable-content-with-pieces)
+[Reusable content with pieces](/tutorials/core-concepts/reusable-content-pieces/)
 
 ## Options
 
@@ -18,7 +18,7 @@ conflicts with the slugs of other piece types.
 
 ## More Options
 
-See [reusable content with pieces](https://docs.apostrophecms.org/apostrophe/tutorials/getting-started/reusable-content-with-pieces)
+See [reusable content with pieces](/tutorials/core-concepts/reusable-content-pieces/)
 for many additional options.
 
 

--- a/modules/apostrophe-pieces/browser-apostrophe-pieces-editor-modal.md
+++ b/modules/apostrophe-pieces/browser-apostrophe-pieces-editor-modal.md
@@ -23,7 +23,13 @@ Make sure the field indicated by options.field is initially visible
 
 ### saveContent(*callback*)
 
-### getErrorMessage(*err*)
+### displayError(*result*)
+Calls getErrorMessage with result.status and passes the
+returned string to apos.notify. This method is a good
+candidate for overrides because it has access to the
+entire result object. Invoked when result.status
+is not `ok`.
+### getErrorMessage(*err*, *result*)
 
 ### beforeConvert(*piece*, *callback*)
 

--- a/modules/apostrophe-pieces/browser-apostrophe-pieces-manager-modal.md
+++ b/modules/apostrophe-pieces/browser-apostrophe-pieces-manager-modal.md
@@ -95,6 +95,11 @@ own implementation.
 shrink and grow make visual reflectments to accommodate the the new Select Everything element
 ### growGrid()
 
+### reflectSelectEverything()
+reflect the modal's layout and size in response to
+whether the select everything box should appear
+at this time. Also reflect the state of the select
+everything checkbox based on what is actually selected
 ### reflectSelectEverythingCheckbox()
 
 ### getSelectAll()

--- a/modules/apostrophe-pieces/browser-apostrophe-pieces.md
+++ b/modules/apostrophe-pieces/browser-apostrophe-pieces.md
@@ -5,6 +5,9 @@ appear anywhere, which is useful for contextual pieces.
 
 
 ## Methods
+### globalLink(*action*, *fn*)
+Globally link up clicks on data-apos-${action} where the piece
+type name is made properly attribute-name-friendly
 ### clickHandlers()
 
 ### manage()

--- a/modules/apostrophe-rich-text-widgets/README.md
+++ b/modules/apostrophe-rich-text-widgets/README.md
@@ -23,3 +23,7 @@ represent it as a data attribute.
 
 ### pushAssets()
 
+### getWidgetClasses(*widget*)
+
+### getWidgetWrapperClasses(*widget*)
+

--- a/modules/apostrophe-schemas/README.md
+++ b/modules/apostrophe-schemas/README.md
@@ -3,14 +3,14 @@
 This module provides schemas, a flexible and fast way to create new data types
 by specifying the fields that should make them up. Schemas power
 [apostrophe-pieces](https://docs.apostrophecms.org/apostrophe/modules/apostrophe-pieces),
-[apostrophe-widgets](https://docs.apostrophecms.org/apostrophe/modules/apostrophe-widgets), custom field
-types in page settings for [apostrophe-custom-pages](https://docs.apostrophecms.org/apostrophe/modules/apostrophe-custom-pages)
+[apostrophe-widgets](/modules/apostrophe-widgets), custom field
+types in page settings for [apostrophe-custom-pages](/modules/apostrophe-custom-pages)
 and more.
 
 A schema is simply an array of "plain old objects." Each object describes one field in the schema
 via `type`, `name`, `label` and other properties.
 
-See the [schema guide](https://docs.apostrophecms.org/apostrophe/tutorials/getting-started/schema-guide) for a complete
+See the [schema guide](/tutorials/schema-guide/schema-guide) for a complete
 overview and list of schema field types. The methods documented here on this page are most often
 used when you choose to work independently with schemas, such as in a custom project
 that requires forms.

--- a/modules/apostrophe-schemas/browser-apostrophe-schemas.md
+++ b/modules/apostrophe-schemas/browser-apostrophe-schemas.md
@@ -48,9 +48,9 @@ for autosave and similar operations.
 
 ### error(*field*, *type*)
 Create a valid error object to be reported from a converter.
-You can also report a string in which case self.convert creates
-one of these for you. The object is nice if you want to extend it
-with extra properties
+You can also report a string as an error in which case self.convert
+creates one of these for you. The object is nice if you want to
+extend it with extra properties
 ### enableGroupTabs(*$el*)
 Add click handlers for group tabs
 ### contextualConvertArea(*data*, *name*, *$el*, *field*)
@@ -62,6 +62,10 @@ Returns true if an editor is actually active for the given area
 
 ### enableArea(*$el*, *name*, *area*, *options*, *callback*)
 options argument may be skipped
+### scheduleEvaQueue()
+
+### runEvaQueue()
+
 ### getSingleton(*$el*, *name*)
 
 ### getArea(*$el*, *name*)

--- a/modules/apostrophe-search/README.md
+++ b/modules/apostrophe-search/README.md
@@ -3,7 +3,7 @@
 Implement sitewide search for Apostrophe. Provides the
 `apostrophe-search` page type for the `/search` page, which
 you should include in your "parked pages" if you wish
-to have one (see [apostrophe-pages](https://docs.apostrophecms.org/apostrophe/modules/apostrophe-pages)).
+to have one (see [apostrophe-pages](/modules/apostrophe-pages)).
 
 Search is powered by the full-text search features of MongoDB.
 

--- a/modules/apostrophe-templates/README.md
+++ b/modules/apostrophe-templates/README.md
@@ -2,7 +2,7 @@
 ### `apos.templates`
 Implements template rendering via Nunjucks. **You should use the
 `self.render` and `self.partial` methods of *your own* module**,
-which exist courtesy of [apostrophe-module](https://docs.apostrophecms.org/apostrophe/modules/apostrophe-module)
+which exist courtesy of [apostrophe-module](/modules/apostrophe-module)
 and invoke methods of this module more conveniently for you.
 
 You may have occasion to call `self.apos.templates.safe` when
@@ -103,6 +103,13 @@ better than the behavior of JSON.stringify (which returns
 ### renderBody(*req*, *type*, *s*, *data*, *module*)
 Implements `render` and `renderString`. See their
 documentation.
+### i18n(*req*, *operation*, *key *, *, additional arguments*)
+Takes `req`, `operation` which will be '__', '__mf' or another
+standard helper name provided by the i18n module, and the
+arguments intended for that helper, beginning always with `key`.
+Invokes the specified operation of the i18n module. This
+method exists as an override and extension point for
+Apostrophe's static text internationalization features.
 ### getEnv(*module*)
 Fetch a nunjucks environment in which `include`,
 `extends`, etc. search the views directories of the
@@ -245,9 +252,16 @@ Invokes all of the `append` helper functions registered for the given
 location and returns the resulting markup as a Nunjucks "safe" string
 (HTML tags are allowed). Available as the `apos.templates.appended`
 helper, and invoked as such by `outerLayoutBase.html`.
+### showContextMenu(*req*)
+Determines whether the aposContextMenu block, which contains
+the "Page Settings" and "Published" UIs in the lower left corner
+in addition to further UI pushed by modules like workflow, should
+appear or not. Override to add additional nuances to this decision.
 ### enableHelpers()
 
 ## Nunjucks template helpers
+### showContextMenu()
+
 ### prepended(*location*)
 Invokes all of the `prepend` helper functions registered for the given
 location and returns the resulting markup as a Nunjucks "safe" string

--- a/modules/apostrophe-ui/README.md
+++ b/modules/apostrophe-ui/README.md
@@ -1,7 +1,7 @@
 ## Inherits from: [apostrophe-module](../apostrophe-module/README.md)
-Provides the [apos.ui](browser-apostrophe-ui.md) singleton on the browser side, which
+Provides the [apos.ui](browser-apostrophe-ui) singleton on the browser side, which
 implements various general purpose UI features for Apostrophe sites, and also
-the [apostrophe-context](../browser-apostrophe-context) base class on the browser side,
+the [apostrophe-context](browser-apostrophe-context) base class on the browser side,
 which is the base class of modals and of other types that benefit from being
 able to make API calls conveniently via `self.action` and link click handlers based on
 `self.$el`.

--- a/modules/apostrophe-users/README.md
+++ b/modules/apostrophe-users/README.md
@@ -13,10 +13,15 @@ Groups are managed by the `apostrophe-groups` module.
 There is also a simplified permissions model in which you just specify
 an array of `groups` as an option to `apostrophe-users`, and a single-select
 dropdown menu allows you to pick one and only one of those groups for each user.
-The properties of each group in the array are `name`, `label` and
-`permissions`, which is an array of permission names such as `guest`, `edit` and
-`admin`. If you specify the `groups` option when configuring
-`apostrophe-users`, the admin interface for `apostrophe-groups` will hide itself.
+The recommended properties of each group in the array are `title`,
+`slug`, and `permissions`, which is an array of permission names such as
+`guest`, `edit` and `admin`. If you specify the `groups` option when
+configuring `apostrophe-users`, the admin interface for
+`apostrophe-groups` will hide itself. Specifying `slug` is optional,
+however if your site has many documents there will be a startup time
+penalty when specifying only `title` due to the lack of indexing
+on that property. For most larger sites we recommend not using the
+`groups` option at all; just manage groups via the admin bar.
 
 ### Public "staff directories" vs. users
 
@@ -71,6 +76,9 @@ can find groups in a consistent way.
 For security, on **ANY** insert of a doc, we check to see if it is
 an `apostrophe-user` and, if so, hash the password, remove it from the doc
 and store the hash in the safe instead.
+
+This method also checks password rules if they are in force
+and local logins are enabled.
 ### docBeforeUpdate(*req*, *doc*, *options*, *callback*)
 For security, on **ANY** update of a doc, we check to see if it is
 an `apostrophe-user` and, if so, hash the password, remove it from the doc

--- a/modules/apostrophe-users/browser-apostrophe-users-editor-modal.md
+++ b/modules/apostrophe-users/browser-apostrophe-users-editor-modal.md
@@ -19,5 +19,7 @@ when creating a new user.
 
 ### updateUsernameViaTitleAttempt(*username*)
 
+### displayError(*result*)
+
 ### getErrorMessage(*err*)
 

--- a/modules/apostrophe-utils/README.md
+++ b/modules/apostrophe-utils/README.md
@@ -160,6 +160,19 @@ ON A LATER AJAX REQUEST TO THE render-widget ROUTE
 
 This way we know this set of options was legitimately part of a recent page rendering
 and therefore is safe to reuse to re-render a widget that is being edited.
+### reinforceBlessing(*req*, *hash*) *[api]*
+Implementation detail of `apos.utils.bless`, do not call directly.
+Sessions have race conditions, which can cause information to
+be lost occasionally, breaking regression tests and sometimes
+irritating real users too. Reinforces the blessing by storing it
+with mongodb's $addToSet when the request ends.
+### reinforceBlessings(*req*) *[api]*
+Implementation detail: determines whether it is worth fetching
+blessings from the database to absolutely guarantee none are
+lost to race conditions with sessions. This takes an extra database
+call, and usually logged in users are the only people editing anyway,
+so we only do it for logged in users by default. Even without this
+blessings are not lost by session race conditions often.
 ### isBlessed(*req*, *options *, *, arg2, arg3...*) *[api]*
 See apos.utils.bless. Checks whether the given set of arguments
 (everything after `req`) has been blessed in the current session.

--- a/modules/apostrophe-video-fields/README.md
+++ b/modules/apostrophe-video-fields/README.md
@@ -1,6 +1,6 @@
 ## Inherits from: [apostrophe-module](../apostrophe-module/README.md)
 ### `apos.videoFields`
-Implements the ["video" apostrophe schema field type](https://docs.apostrophecms.org/apostrophe/tutorials/getting-started/schema-guide).
+Implements the ["video" apostrophe schema field type](/tutorials/advanced-topics/schema-guide).
 
 The value of the field is an object with `url`, `title` and `thumbnail` properties, the latter
 two being as obtained by `oembetter` at the time the URL was originally pasted and fetched

--- a/modules/apostrophe-video-widgets/README.md
+++ b/modules/apostrophe-video-widgets/README.md
@@ -1,7 +1,7 @@
 ## Inherits from: [apostrophe-widgets](../apostrophe-widgets/README.md)
 Provides the `apostrophe-video` widget, which displays videos, powered
-by [apostrophe-video-field](https://docs.apostrophecms.org/apostrophe/modules/apostrophe-video-fields) and
-[apostrophe-oembed](https://docs.apostrophecms.org/apostrophe/modules/apostrophe-oembed). The video
+by [apostrophe-video-field](/modules/apostrophe-video-fields) and
+[apostrophe-oembed](/modules/apostrophe-oembed). The video
 widget accepts the URL of a video on any website that supports the
 [oembed](http://oembed.com/) standard, including vimeo, YouTube, etc.
 In some cases the results are refined by oembetter filters configured

--- a/modules/apostrophe-widgets/README.md
+++ b/modules/apostrophe-widgets/README.md
@@ -1,14 +1,14 @@
 ## Inherits from: [apostrophe-module](../apostrophe-module/README.md)
 The base class for all modules that implement a widget, such as
-[apostrophe-rich-text-widgets](../apostrophe-rich-text-widgets/README.md),
-[apostrophe-pieces-widgets](../apostrophe-pieces-widgets/README.md) and
-[apostrophe-video-widgets](../apostrophe-video-widgets/README.md).
+[apostrophe-rich-text-widgets](/modules/apostrophe-rich-text-widgets/),
+[apostrophe-pieces-widgets](/modules/apostrophe-pieces-widgets/) and
+[apostrophe-video-widgets](/modules/apostrophe-video-widgets/).
 
-All widgets have a [schema](/tutorials/schema-guide/schema-guide.md).
+All widgets have a [schema](../../tutorials/getting-started/schema-guide.html).
 Many project-specific modules that extend this module consist entirely of an
 `addFields` option and a `views/widget.html` file.
 
-For more information see the [custom widgets tutorial](/tutorials/core-concepts/editable-content-on-pages/custom-widgets.md).
+For more information see the [custom widgets tutorial](/tutorials/core-concepts/editable-content-on-pages/custom-widgets.
 
 ## Options
 
@@ -59,7 +59,7 @@ subclass of `apostrophe-custom-pages` or `apostrophe-pieces-pages`, as well.
 
 ### `addFields`, `removeFields`, `arrangeFields`, etc.
 
-The standard options for building [schemas](/tutorials/schema-guide/schema-guide.md)
+The standard options for building [schemas](/tutorials/advanced-topics/schema-guide)
 are accepted. The widget will present a modal dialog box allowing the user to edit
 these fields. They are then available inside `widget.html` as properties of
 `data.widget`.
@@ -103,7 +103,7 @@ the appropriate div, the `data` for the widget, and the `options` that
 were passed to the widget.
 
 For example, here is the `public/js/always.js` file for the
-[apostrophe-video-widgets](../apostrophe-video-widgets/README.md) module:
+[apostrophe-video-widgets](../apostrophe-video-widgets/index.html) module:
 
 ```javascript
 apos.define('apostrophe-video-widgets', {
@@ -186,9 +186,9 @@ array, only the named permanent properties are supplied. If `playerData is `true
 (the default), all of the permanent properties are supplied.
 ### filterOptionsForDataAttribute(*options*)
 Filter options passed from the template to the widget before stuffing
-them into JSON for use by the widget editor. Again, we discard all
-properties that are the results of joins or otherwise dynamic
-(arrays or objects named with a leading `_`).
+them into JSON for use by widget players and the widget editor. Again,
+by default we discard all properties that are the results of joins or
+otherwise dynamic (arrays or objects named with a leading `_`).
 
 If we don't do a good job here we get 1MB+ of markup. So if you override
 this, play nice. And think about fetching the data you need only when

--- a/modules/apostrophe-widgets/README.md
+++ b/modules/apostrophe-widgets/README.md
@@ -4,7 +4,7 @@ The base class for all modules that implement a widget, such as
 [apostrophe-pieces-widgets](/modules/apostrophe-pieces-widgets/) and
 [apostrophe-video-widgets](/modules/apostrophe-video-widgets/).
 
-All widgets have a [schema](../../tutorials/getting-started/schema-guide.html).
+All widgets have a [schema](/tutorials/schema-guide/schema-guide.md).
 Many project-specific modules that extend this module consist entirely of an
 `addFields` option and a `views/widget.html` file.
 
@@ -103,7 +103,7 @@ the appropriate div, the `data` for the widget, and the `options` that
 were passed to the widget.
 
 For example, here is the `public/js/always.js` file for the
-[apostrophe-video-widgets](../apostrophe-video-widgets/index.html) module:
+[apostrophe-video-widgets](../apostrophe-video-widgets/README.md) module:
 
 ```javascript
 apos.define('apostrophe-video-widgets', {

--- a/modules/apostrophe-widgets/browser-apostrophe-widgets-editor.md
+++ b/modules/apostrophe-widgets/browser-apostrophe-widgets-editor.md
@@ -7,7 +7,7 @@
 
 ### beforeShow(*callback*)
 
-### afterShow(*callback*)
+### afterShow()
 Wait for afterShow to do things that might pop more modals
 ### getData()
 


### PR DESCRIPTION
Resolves #215 

The money is in `945099b`, ("👉 The Fix: captures methods with spaces before the parens"). I generated the references to test the fix and figured it'd be good to get those updates in as well. Reviewing the commits individually will be helpful on this one.