### PR TITLE
Fix `addFilter` command in Nunjucks helpers

### DIFF
--- a/docs/core-concepts/working-with-templates/nunjucks-helper-functions.md
+++ b/docs/core-concepts/working-with-templates/nunjucks-helper-functions.md
@@ -182,7 +182,7 @@ module.exports = {
     }
   ],
   construct: function(self, options) {
-    self.apos.templates.addFilters({
+    self.apos.templates.addFilter({
       stripHttp: function (s) {
         return s.replace(/^(https?:|)\/\//, '');
       }


### PR DESCRIPTION
No `addFilters` function in `apostrophe/lib/modules/apostrophe-templates` but  `addFilter` instead