### PR TITLE
Fix/allowed classes

### DIFF
--- a/docs/core-concepts/editable-content-on-pages/standard-widgets.md
+++ b/docs/core-concepts/editable-content-on-pages/standard-widgets.md
@@ -31,6 +31,8 @@ The name of the area. This denotes what property the singleton will be saved to 
 
 `styles` specifies an array of valid CKEditor styles, which will appear on the "Style" dropdown menu if it is included in the `toolbar`. Each style has a `name` property and an `element` property. Most semantic HTML5 elements are allowed here.
 
+Learn more about connfiguring the rich text widget in [the CKEditor configuration section](/howtos/ckeditor.md).
+
 ### `apostrophe-images`
 
 The `apostrophe-images` widget lets you add one or more images. If multiple images are added in a single widget, they are presented as a slideshow.

--- a/docs/devops/deployment/deploying-apostrophe-in-the-cloud-with-aws.md
+++ b/docs/devops/deployment/deploying-apostrophe-in-the-cloud-with-aws.md
@@ -381,7 +381,7 @@ To ensure the contents of the bundle's `data/` subdirectory are still available,
 
 To ensure there are no CORS (Cross-Origin Resource) errors, visit your amazon S3 bucket settings to adjust the CORS configuration:
 
-`Amazon S3 --> [bucket] --> Permissions Tab --> CORS configuration button`
+`Amazon S3 → [bucket] → Permissions Tab → CORS configuration button`
 
 Verify the value of `AllowedOrigin`. It should match the Elastic Beanstalk URL and/or the production URL of your project:
 

--- a/docs/devops/deployment/deploying-apostrophe-in-the-cloud-with-heroku.md
+++ b/docs/devops/deployment/deploying-apostrophe-in-the-cloud-with-heroku.md
@@ -225,7 +225,7 @@ Victory!
 
 To ensure there are no CORS (Cross-Origin Resource) errors, visit your amazon S3 bucket settings to adjust the CORS configuration:
 
-`Amazon S3 --> [bucket] --> Permissions Tab --> CORS configuration button`
+`Amazon S3 → [bucket] → Permissions Tab → CORS configuration button`
 
 Verify the value of `AllowedOrigin`. It should match the heroku url and/or the production URL of your project:
 

--- a/docs/howtos/ckeditor.md
+++ b/docs/howtos/ckeditor.md
@@ -16,41 +16,6 @@ It's easy to change: just set the `sanitizeHtml` option in `lib/modules/apostrop
 
 Here are a few common configurations. For more, [see the `sanitize-html` documentation](https://npmjs.org/package/sanitize-html).
 
-### Allow additional HTML tags
-
-The **default** `allowedTags` configuration from `sanitize-html` is:
-
-```javascript
-  allowedTags: [
-    'h3', 'h4', 'h5', 'h6', 'blockquote',
-    'p', 'a', 'ul', 'ol', 'nl', 'li',
-    'b', 'i', 'strong', 'em', 'strike', 'abbr',
-    'code', 'hr', 'br', 'div', 'caption',
-    'table', 'thead', 'tbody', 'tr', 'th', 'td', 'pre', 'iframe'
-  ],
-```
-
-To add tags to that list, you would include all of those tags you want to keep, then add the new ones.  Here is an example adding `sup` and `sub`:
-
-```javascript
-// lib/modules/apostrophe-rich-text-widgets/index.js
-
-module.exports = {
-  // The standard list copied from the module, plus sup and sub
-  sanitizeHtml: {
-    allowedTags: [
-      'h3', 'h4', 'h5', 'h6', 'blockquote',
-      'p', 'a', 'ul', 'ol', 'nl', 'li',
-      'b', 'i', 'strong', 'em', 'strike', 'abbr',
-      'code', 'hr', 'br', 'div', 'caption',
-      'table', 'thead', 'tbody', 'tr', 'th', 'td', 'pre', 'iframe',
-      'sup', 'sub' // ⬅ The new tags
-    ],
-    // ...,
-  }
-};
-```
-
 ### Add text styles using classes
 
 You will often want to add styles to the rich text editor widget that use classes for visual styling. For example, you may have these configurations in an area with a rich text widget for a basic paragraph and two special styles:
@@ -98,7 +63,9 @@ module.exports = {
 };
 ```
 
+::: tip
 You can open this up to allow the `class` attribute on any element by replacing those individual tag name keys in `allowedAttributes` with an asterisk string (`'*': ['class']`).
+:::
 
 Alternatively, you could only allow specific classes. You may not want to allow people to paste in rich text from somewhere else that includes classes that don't work well in a certain context. In this approach, you would use `allowClasses`:
 
@@ -119,6 +86,41 @@ module.exports = {
 ```
 
 There are no default `allowedClasses` settings, so you don't need to worry about including defaults for this one.
+
+### Allow additional HTML tags
+
+The **default** `allowedTags` configuration from `sanitize-html` is:
+
+```javascript
+  allowedTags: [
+    'h3', 'h4', 'h5', 'h6', 'blockquote',
+    'p', 'a', 'ul', 'ol', 'nl', 'li',
+    'b', 'i', 'strong', 'em', 'strike', 'abbr',
+    'code', 'hr', 'br', 'div', 'caption',
+    'table', 'thead', 'tbody', 'tr', 'th', 'td', 'pre', 'iframe'
+  ],
+```
+
+To add tags to that list, you would include all of those tags you want to keep, then add the new ones.  Here is an example adding `sup` and `sub`:
+
+```javascript
+// lib/modules/apostrophe-rich-text-widgets/index.js
+
+module.exports = {
+  // The standard list copied from the module, plus sup and sub
+  sanitizeHtml: {
+    allowedTags: [
+      'h3', 'h4', 'h5', 'h6', 'blockquote',
+      'p', 'a', 'ul', 'ol', 'nl', 'li',
+      'b', 'i', 'strong', 'em', 'strike', 'abbr',
+      'code', 'hr', 'br', 'div', 'caption',
+      'table', 'thead', 'tbody', 'tr', 'th', 'td', 'pre', 'iframe',
+      'sup', 'sub' // ⬅ The new tags
+    ],
+    // ...,
+  }
+};
+```
 
 There are many other combinations of similar configurations you may need to use. For more, [see the `sanitize-html` documentation](https://npmjs.org/package/sanitize-html).
 

--- a/docs/howtos/ckeditor.md
+++ b/docs/howtos/ckeditor.md
@@ -2,7 +2,46 @@
 
 Apostrophe uses [CKEditor](http://docs.ckeditor.com/) for rich text editing. It's a great rich text editor that seriously addresses the many cross-browser compatibility issues that come up due to the fact that each browser has its own unique implementation of the underlying rich text edit functionality.
 
-You've [seen how to add a rich text widget to a page and configure styles and toolbar controls](/core-concepts/pages-and-navigation/widgets-singletons-and-areas.md), but sometimes you'll want to go beyond that and configure CKEditor in ways we didn't anticipate. Here's how you can do that.
+You've [seen how to add a rich text widget to a page and configure styles and toolbar controls](/core-concepts/pages-and-navigation/widgets-singletons-and-areas.md), but sometimes you'll want to go beyond that and configure CKEditor for your project's specific needs. Here's how you can do that.
+
+## Changing the allowed HTML tags in rich text
+
+Some CKEditor configurations introduce new HTML tags that might be present in the markup. It looks great in the editor, but when you refresh the page they are gone. What happened?
+
+Apostrophe automatically filters all rich text through the [sanitize-html](https://npmjs.org/package/sanitize-html) module. This prevents XSS attacks and also prevents the page design from being wrecked by bad or just plain ugly markup pasted from desktop applications.
+
+However, sometimes the default configuration isn't working for you, for instance because you want to add `sub` and `sup` to the list of allowed tags.
+
+It's easy to change: just set the `sanitizeHtml` option in `lib/modules/apostrophe-rich-text-widgets/index.js` in your project. Just keep in mind that **if you configure one of the sanitizeHtml options at all, you must configure that option completely.** A common mistake is forgetting to allow `a` elements or the `http` protocol, resulting in very pretty text with no links allowed!
+
+Here is an example of a complete copy of the default `sanitize-html` configuration that also adds `sup` and `sub`:
+
+```javascript
+// lib/modules/apostrophe-rich-text-widgets/index.js
+
+module.exports = {
+  // The standard list copied from the module, plus sup and sub
+  sanitizeHtml: {
+    allowedTags: [ 'h3', 'h4', 'h5', 'h6', 'blockquote', 'p', 'a', 'ul', 'ol',
+      'li', 'b', 'i', 'strong', 'em', 'strike', 'code', 'hr', 'br', 'div',
+      'table', 'thead', 'caption', 'tbody', 'tr', 'th', 'td', 'pre',
+      'sup', 'sub'
+    ],
+    allowedAttributes: {
+      a: [ 'href', 'name', 'target' ],
+      // We don't currently allow img itself by default, but this
+      // would make sense if we did
+      img: [ 'src' ]
+    },
+    // Lots of these won't come up by default because we don't allow them
+    selfClosing: [ 'img', 'br', 'hr', 'area', 'base', 'basefont',
+      'input', 'link', 'meta' ],
+    // URL schemes we permit
+    allowedSchemes: [ 'http', 'https', 'ftp', 'mailto' ],
+    allowedSchemesByTag: {}
+  }
+};
+```
 
 ## Global CKeditor configuration
 
@@ -77,47 +116,3 @@ apos.define('apostrophe-rich-text-widgets-editor', {
 > If we want to, we can look at `self.options.templateOptions`, which contains the configuration passed to this widget by `apos.areas` or `apos.singleton`.
 
 > Apostrophe's initial definition of the `beforeCkeditorInline` method is empty (following the [template pattern](https://en.wikipedia.org/wiki/Template_method_pattern)), but if you are using various add-on modules it's possible that some of them define it. If you want to be sure that code is called too, use the [super pattern](/reference/glossary.md#super-pattern) rather than just replacing the method outright.
-
-## Changing the allowed HTML tags in rich text
-
-Some CKEditor configurations introduce new HTML tags that might be present in the markup. It looks great in the editor, but when you refresh the page they are gone. What happened?
-
-Apostrophe automatically filters all rich text through the [sanitize-html](https://npmjs.org/package/sanitize-html) module. This prevents XSS attacks and also prevents the page design from being wrecked by bad or just plain ugly markup pasted from desktop applications.
-
-However, sometimes the default configuration isn't working for you, for instance because you want to add `sub` and `sup` to the list of allowed tags.
-
-It's easy to change: just set the `sanitizeHtml` option in `lib/modules/apostrophe-rich-text-widgets/index.js` in your project. Just keep in mind that **if you configure one of the sanitizeHtml options at all, you must configure that option completely.** A common mistake is forgetting to allow `a` elements or the `http` protocol, resulting in very pretty text with no links allowed!
-
-Here is an example of a complete copy of the default `sanitize-html` configuration that also adds `sup` and `sub`:
-
-```javascript
-// lib/modules/apostrophe-rich-text-widgets/index.js
-
-module.exports = {
-  // The standard list copied from the module, plus sup and sub
-  sanitizeHtml: {
-    allowedTags: [ 'h3', 'h4', 'h5', 'h6', 'blockquote', 'p', 'a', 'ul', 'ol',
-      'li', 'b', 'i', 'strong', 'em', 'strike', 'code', 'hr', 'br', 'div',
-      'table', 'thead', 'caption', 'tbody', 'tr', 'th', 'td', 'pre',
-      'sup', 'sub'
-    ],
-    allowedAttributes: {
-      a: [ 'href', 'name', 'target' ],
-      // We don't currently allow img itself by default, but this
-      // would make sense if we did
-      img: [ 'src' ]
-    },
-    // Lots of these won't come up by default because we don't allow them
-    selfClosing: [ 'img', 'br', 'hr', 'area', 'base', 'basefont',
-      'input', 'link', 'meta' ],
-    // URL schemes we permit
-    allowedSchemes: [ 'http', 'https', 'ftp', 'mailto' ],
-    allowedSchemesByTag: {}
-  }
-};
-```
-
-
-
-
-

--- a/docs/howtos/ckeditor.md
+++ b/docs/howtos/ckeditor.md
@@ -14,7 +14,23 @@ However, sometimes the default configuration isn't working for you, for instance
 
 It's easy to change: just set the `sanitizeHtml` option in `lib/modules/apostrophe-rich-text-widgets/index.js` in your project. Just keep in mind that **if you configure one of the sanitizeHtml options at all, you must configure that option completely.** A common mistake is forgetting to allow `a` elements or the `http` protocol, resulting in very pretty text with no links allowed!
 
-Here is an example of a complete copy of the default `sanitize-html` configuration that also adds `sup` and `sub`:
+Here are a few common configurations. For more, [see the `sanitize-html` documentation](https://npmjs.org/package/sanitize-html).
+
+### Allow additional HTML tags
+
+The **default** `allowedTags` configuration from `sanitize-html` is:
+
+```javascript
+  allowedTags: [
+    'h3', 'h4', 'h5', 'h6', 'blockquote',
+    'p', 'a', 'ul', 'ol', 'nl', 'li',
+    'b', 'i', 'strong', 'em', 'strike', 'abbr',
+    'code', 'hr', 'br', 'div', 'caption',
+    'table', 'thead', 'tbody', 'tr', 'th', 'td', 'pre', 'iframe'
+  ],
+```
+
+To add tags to that list, you would include all of those tags you want to keep, then add the new ones.  Here is an example adding `sup` and `sub`:
 
 ```javascript
 // lib/modules/apostrophe-rich-text-widgets/index.js
@@ -22,26 +38,89 @@ Here is an example of a complete copy of the default `sanitize-html` configurati
 module.exports = {
   // The standard list copied from the module, plus sup and sub
   sanitizeHtml: {
-    allowedTags: [ 'h3', 'h4', 'h5', 'h6', 'blockquote', 'p', 'a', 'ul', 'ol',
-      'li', 'b', 'i', 'strong', 'em', 'strike', 'code', 'hr', 'br', 'div',
-      'table', 'thead', 'caption', 'tbody', 'tr', 'th', 'td', 'pre',
-      'sup', 'sub'
+    allowedTags: [
+      'h3', 'h4', 'h5', 'h6', 'blockquote',
+      'p', 'a', 'ul', 'ol', 'nl', 'li',
+      'b', 'i', 'strong', 'em', 'strike', 'abbr',
+      'code', 'hr', 'br', 'div', 'caption',
+      'table', 'thead', 'tbody', 'tr', 'th', 'td', 'pre', 'iframe',
+      'sup', 'sub' // ⬅ The new tags
     ],
-    allowedAttributes: {
-      a: [ 'href', 'name', 'target' ],
-      // We don't currently allow img itself by default, but this
-      // would make sense if we did
-      img: [ 'src' ]
-    },
-    // Lots of these won't come up by default because we don't allow them
-    selfClosing: [ 'img', 'br', 'hr', 'area', 'base', 'basefont',
-      'input', 'link', 'meta' ],
-    // URL schemes we permit
-    allowedSchemes: [ 'http', 'https', 'ftp', 'mailto' ],
-    allowedSchemesByTag: {}
+    // ...,
   }
 };
 ```
+
+### Add text styles using classes
+
+You will often want to add styles to the rich text editor widget that use classes for visual styling. For example, you may have these configurations in an area with a rich text widget for a basic paragraph and two special styles:
+
+```django
+  {{ apos.area(data.page, 'body', {
+    widgets: {
+      'apostrophe-rich-text': {
+        toolbar: [ 'Styles', 'Bold', 'Italic', 'Link', 'Unlink' ],
+        styles: [
+          { element: 'p', name: 'Paragraph' },
+          {
+            element: 'p',
+            name: 'Featured text',
+            attributes: { class: 'featured-text' }
+          },
+          {
+            element: 'h3',
+            name: 'Section title',
+            attributes: { class: 'section-heading' }
+          }
+        ]
+      }
+    }
+  }) }}
+```
+
+You can allow these classes in two ways. First, you could allow all classes on those elements using `allowedAttributes`:
+
+```javascript
+// lib/modules/apostrophe-rich-text-widgets/index.js
+
+module.exports = {
+  // The standard list copied from the module, plus sup and sub
+  sanitizeHtml: {
+    // allowedTags: [...],
+    allowedAttributes: {
+      'p': ['class'],
+      'h3': ['class'],
+      // Include the default setting as well, or else links will break
+      'a': [ 'href', 'name', 'target' ]
+    },
+    // ...,
+  }
+};
+```
+
+You can open this up to allow the `class` attribute on any element by replacing those individual tag name keys in `allowedAttributes` with an asterisk string (`'*': ['class']`).
+
+Alternatively, you could only allow specific classes. You may not want to allow people to paste in rich text from somewhere else that includes classes that don't work well in a certain context. In this approach, you would use `allowClasses`:
+
+```javascript
+// lib/modules/apostrophe-rich-text-widgets/index.js
+
+module.exports = {
+  // The standard list copied from the module, plus sup and sub
+  sanitizeHtml: {
+    // allowedTags: [...],
+    allowedClasses: {
+      'p': [ 'featured-text' ],
+      'h3': [ 'section-heading' ]
+    },
+    // ...,
+  }
+};
+```
+
+There are no default `allowedClasses` settings, so you don't need to worry about including defaults for this one.
+
+There are many other combinations of similar configurations you may need to use. For more, [see the `sanitize-html` documentation](https://npmjs.org/package/sanitize-html).
 
 ## Global CKeditor configuration
 


### PR DESCRIPTION
Redresses the lack of `allowedClasses` documentation referenced in https://github.com/apostrophecms/apostrophe/issues/754