### PR TITLE
Rephrases custom image size reference

### DIFF
--- a/docs/core-concepts/editable-content-on-pages/standard-widgets.md
+++ b/docs/core-concepts/editable-content-on-pages/standard-widgets.md
@@ -74,7 +74,7 @@ Here is an example with the popular options:
 
 If you don't specify a size, the `full` size is displayed.
 
-You'll talk about adding custom image sizes in [`apostrophe-attachments`](/reference/modules/apostrophe-attachments/README.md#addimagesizes) in a later tutorial.
+See [`apostrophe-attachments`](/reference/modules/apostrophe-attachments/README.md#addimagesizes) for information about adding custom image sizes with that module's `addImageSizes` option.
 
 ### `apostrophe-files`
 


### PR DESCRIPTION
Closes #39. Not adding a tutorial, but the docs in apos-attachments are pretty good already. We also don't want to be confusing, suggesting there is a different tutorial that will cover more.