### PR TITLE
Remove the trailing Closing brackets

### DIFF
--- a/docs/advanced-topics/promise-events/promise-events.md
+++ b/docs/advanced-topics/promise-events/promise-events.md
@@ -207,7 +207,7 @@ module.exports = {
     self.on('apostrophe-pages:beforeSend', 'addWeather', async function(req) {
       const forecast = await request('http://api.openweathermap.org/data/2.5/forecast?id=5205788&APPID=PUTYOUROWNAPIKEYHERE');
       req.data.forecast = forecast;
-    });
+    };
   }
 }
 ```


### PR DESCRIPTION
Overriding an existing promise event handler, the example given has a slight syntax error, a trailing closing brackets.