### PR TITLE
Fix: piece url pointing to external site.

### DIFF
--- a/docs/advanced-topics/advanced-pieces-topics/overriding-piece-urls.md
+++ b/docs/advanced-topics/advanced-pieces-topics/overriding-piece-urls.md
@@ -58,7 +58,7 @@ module.exports = {
   construct: (self, options) => {
     self.addUrls = (req, pieces, callback) => {
       for (const piece of pieces) {
-        piece._url = `https://external-site.com/products/${piece}.slug`;
+        piece._url = `https://external-site.com/products/${piece.slug}`;
       }
       return callback(null);
     };


### PR DESCRIPTION
Properly retrieve the `piece`'s slug used in external site's url.