### PR TITLE
Description of disableAdminPiecesEditing option for apostrophe-permissions

### DIFF
--- a/docs/reference/modules/apostrophe-permissions.md
+++ b/docs/reference/modules/apostrophe-permissions.md
@@ -3,6 +3,17 @@
 ### `apos.permissions`
 This module manages the permissions of docs in Apostrophe.
 
+## Options
+
+`disableAdminPiecesEditing`
+
+By default, assigning any admin piece permissions to a group 
+(i.e. 'admin-apostrophe-image') will enable admin bar controls for 
+all other pieces. This is to make management of related items simpler in 
+management dialogs. If this option is set to `true`, the admin bar will 
+only show piece types that the user's group has been given explicit 
+admin or edit permissions on. You will need to manage permissions for 
+any joined pieces that also need to be editable.
 
 ## Methods
 ### can(*req*, *action*, *object*, *newObject*) *[api]*


### PR DESCRIPTION
Related to pull request #3026 for apostrophecms/apostrophe.

Adding documentation for new disableAdminPiecesEditing option in apostrophe-permissions. Also added an Options header for the page, as it didn't exist previously.