### PR TITLE
self.get('nameOfFilter')

### DIFF
--- a/docs/advanced-topics/database/cursors.md
+++ b/docs/advanced-topics/database/cursors.md
@@ -139,7 +139,7 @@ module.exports = {
       },
       safeFor: 'public',
       finalize: function() {
-        const popular = self.get('popular');
+        const popular = self.get('busy');
         if (popular) {
           // MongoDB dot notation
           self.and({ 'jobsIds.1': { $exists: 1 } });


### PR DESCRIPTION
As per https://docs.apostrophecms.org/reference/modules/apostrophe-docs/server-apostrophe-cursor.html#methods. the self.get should get the nameOfFilter. In this case the name of the filter is busy. Unless I misunderstood it.