### PR TITLE
Disables Algolia deep search

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -88,11 +88,11 @@ module.exports = {
           }
         ]
       }
-    ],
-    algolia: {
-      apiKey: 'e11d95029c6a9ac596343664b7f622e4',
-      indexName: 'apostrophecms'
-    }
+    ]
+    // algolia: {
+    //   apiKey: 'e11d95029c6a9ac596343664b7f622e4',
+    //   indexName: 'apostrophecms'
+    // }
   },
   head: [
     // <script type="text/javascript" id="hs-script-loader" async defer src="//js.hs-scripts.com/6104347.js"></script>


### PR DESCRIPTION
Because of the URL changes Algolia search is indexing is bringing up nothing. Reverting to the heading search for now.